### PR TITLE
BAU: Add deployment of proxy secrets

### DIFF
--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -37,5 +37,29 @@ jobs:
 
       - name: Build
         run: bundle exec middleman build
+
+      - name: Create Credentials
+        shell: bash
+        env:
+          CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          COOKIE_SECRET: ${{ secrets.PROXY_COOKIE_SECRET }}
+        run: |
+          set +e
+          export CREDENTIALS="$(jq -n '{ client_id: $client_id, client_secret: $client_secret, cookie_secret: $cookie_secret }' \
+            --arg client_id "${CLIENT_ID}" \
+            --arg client_secret "${CLIENT_SECRET}" \
+            --arg cookie_secret "${COOKIE_SECRET}" \
+          )"
+          cf service auth-tech-docs-proxy-credentials > /dev/null
+          if [[ $? == 0 ]]; then
+            cf update-user-provided-service auth-tech-docs-proxy-credentials -p "${CREDENTIALS}"
+          else
+            cf create-user-provided-service auth-tech-docs-proxy-credentials -p "${CREDENTIALS}"
+          fi
+
       - name: Push to PaaS
         run: cf push
+
+      - name: Create Network Policies
+        run: cf add-network-policy di-auth-tech-docs-proxy di-auth-tech-docs-website --protocol tcp --port 8080

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,15 @@
 ---
 applications:
-- name: auth-tech-docs
+- name: di-auth-tech-docs-proxy
+  path: ./proxy
+  buildpacks:
+    - https://github.com/andy-paine/env-map-buildpack.git
+    - binary_buildpack
+  services:
+    - auth-tech-docs-proxy-credentials
+  routes:
+    - route: auth-tech-docs.london.cloudapps.digital
+- name: di-auth-tech-docs-website
   memory: 64M
-  instances: 2
+  routes:
+    - route: auth-tech-docs.apps.internal

--- a/proxy/env-map.yml
+++ b/proxy/env-map.yml
@@ -1,4 +1,4 @@
 env_vars:
-  OAUTH2_PROXY_CLIENT_ID: ."user-provided"[0].credentials.oauth_client_id
-  OAUTH2_PROXY_CLIENT_SECRET: ."user-provided"[0].credentials.oauth_client_secret
+  OAUTH2_PROXY_CLIENT_ID: ."user-provided"[0].credentials.client_id
+  OAUTH2_PROXY_CLIENT_SECRET: ."user-provided"[0].credentials.client_secret
   OAUTH2_PROXY_COOKIE_SECRET: ."user-provided"[0].credentials.cookie_secret


### PR DESCRIPTION
## Why

We protected team technical manuals with GitHub auth, adding this in.

## What

- Add OAuth2 Proxy configuration
- Update deploy-to-paas workflow to only trigger on main
- Update deploy-to-paas workflow to push secrets and create network policies

## Technical writer support

N/A
