### PR TITLE
BAU: Limit the amount of memory allocated to OAuth2 proxy

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: di-auth-tech-docs-proxy
   path: ./proxy
+  memory: 32M
   buildpacks:
     - https://github.com/andy-paine/env-map-buildpack.git
     - binary_buildpack


### PR DESCRIPTION
## Why

The default of 1G is far too much given our current overall memory limits.

## What

- No explicit limit was set, so it seemed to be defaulting 1G

## Technical writer support

N/A