### PR TITLE
simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ This will allow you to compile Ruby, and makes it easier to manage multiple Ruby
 
 Download the current version of Ruby that the [application uses](.ruby-version):
 ```
-rbenv install $(cat .ruby-version)
-```
-
-Set your local Ruby version to match what `rbenv` installed in the previous step:
-```
-rbenv local $(cat .ruby-version)
+rbenv install
 ```
 
 Install the application's dependencies:
@@ -37,7 +32,8 @@ There's an incompatibility issue with the latest MacOS and the `ffi` library whi
 To fix the issue you must stop the `ffi` gem using the native `libffi` library by sending this command:
 
 ```shell script
-gem install ffi -- --disable-system-libffi
+bundle config build.ffi --disable-system-libffi
+bundle install # reinstall
 ```
 
 ## Making changes


### PR DESCRIPTION
`rbenv install` implicitly reads .ruby-version, you don't need to
specify it.

`rbenv local` sets the value of .ruby-version.  Setting the value to
the current .ruby-version file is a no-op.

We should configure bundler to build the ffi gem for us, rather than
doing it in a weird way here.

## Why

Shorter is better

## What

see above

## Technical writer support

Not needed

## How to review

Tell reviewers how to assess your changes.
