### PR TITLE
updates header text to remove duplicate GOV.UK

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: https://auth-tech-docs.cloudapps.digital
 
 # Header-related options
 show_govuk_logo: true
-service_name: GOV.UK Sign In
+service_name: Sign In
 service_link: https://www.sign-in.service.gov.uk/
 
 


### PR DESCRIPTION
## Why

Duplicate Sign In text on the header. This will remove one. 
