### PR TITLE
Add section on what an RP needs to consider before integrating with GOV.UK One Login

### DIFF
--- a/source/before-integrating/index.html.md.erb
+++ b/source/before-integrating/index.html.md.erb
@@ -44,11 +44,11 @@ You must use individual configurations for each of your services to get the foll
 * effective monitoring and detection of fraudulent activity
 * better help for your users because the support team will have more detailed information on user activity
 
-If you are not using individual configurations for each of your services, be aware that:
+If you do not use individual configurations for each of your services, GOV.UK One Login cannot:
 
-* fraudulent activity cannot be easily profiled and detected
-* you cannot get service specific analytics and we cannot generate these retrospectively in case you decide not to have individual configurations from the start
-* your users cannot benefit from simplified navigation and service specific information through their user journey
+* monitor or detect fraudulent activities as effectively 
+* give you service specific analytics - we cannot generate this retrospectively if you later switch to individual configurations 
+* provide your users with a simpler and more personalised user journey
 
 Organisations with multiple services may have additional requirements such as:
 

--- a/source/before-integrating/index.html.md.erb
+++ b/source/before-integrating/index.html.md.erb
@@ -39,11 +39,10 @@ When you are ready to set up your service’s configuration, follow the guidance
 
 You must use individual configurations for each of your services to get the following benefits: 
 
-* GOV.UK One Login can provide a report detailing each service’s performance including success rates and volumes
-* if a service gets compromised, the outage is limited to an individual service
-* fraud analysis can use information about how users access different services and better profile and detect fraudulent behaviour
-* the support team has more context regarding user activity and can better support with user queries
-* users have visibility on all available services and their activity logs which makes navigation to specific services easier and suspicious activities more likely to be detected  
+* service specific reports with information about success rates and volumes
+* protection for each service if another service has an outage - your other services will not be affected
+* effective monitoring and detection of fraudulent activity
+* better help for your users because the support team will have more detailed information on user activity
 
 If you are not using individual configurations for each of your services, be aware that:
 

--- a/source/before-integrating/index.html.md.erb
+++ b/source/before-integrating/index.html.md.erb
@@ -1,0 +1,60 @@
+---
+title: Before you integrate with GOV.UK One Login
+weight: 2.0
+last_reviewed_on: 2023-09-15
+review_in: 6 months
+---
+
+# Before you integrate with GOV.UK One Login
+
+Before you begin your integration with GOV.UK One Login, you should consider:
+
+* how many services within your organisation you’re planning to integrate
+* if your services need to share users, in case you’re integrating more than 1 service
+* if you need to create a reusable component to standardise integration across your organisation, in case you’re integrating a large number of services
+* what the scope of your individual services is and whether this meets the GOV.UK Service Standard definition of a service 
+
+If you’re integrating multiple services, you should [create a configuration for each service you’re integrating](/before-integrating/#create-a-configuration-for-each-service-you-re-integrating). 
+
+Make sure you scope your services according to the [GOV.UK Service Standard guidance](https://www.gov.uk/service-manual/service-standard) on how users think and what they need to do. Find more [information on scoping your service](https://www.gov.uk/service-manual/design/scoping-your-service). 
+
+## Create a configuration for each service you’re integrating
+
+GOV.UK One Login is an OpenID Connect (OIDC) provider. An OIDC ‘relying party’ is an app that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
+
+To interact with GOV.UK One Login, you must first [register each of your services with GOV.UK One Login as a relying party](/integrate-with-integration-environment/manage-your-service-s-configuration/#register-your-service-to-use-gov-uk-one-login). You need to do this for each of the services that you want to integrate with GOV.UK One Login.
+
+Part of the service’s configuration is the `client-id`, which is a unique identifier that GOV.UK One Login uses to identify your services. Each service should have a distinct `client-id`.
+
+GOV.UK One Login uses `client-id` for: 
+
+* retrieving configurations
+* event auditing
+* performance analytics 
+* fraud prevention and data sharing
+
+When you are ready to set up your service’s configuration, follow the guidance on how to [manage your service’s configuration with GOV.UK One Login](/integrate-with-integration-environment/manage-your-service-s-configuration/#manage-your-service-s-configuration-with-gov-uk-one-login).
+
+### Why you should use a specific configuration for each service
+
+You must use individual configurations for each of your services to get the following benefits: 
+
+* GOV.UK One Login can provide a report detailing each service’s performance including success rates and volumes
+* if a service gets compromised, the outage is limited to an individual service
+* fraud analysis can use information about how users access different services and better profile and detect fraudulent behaviour
+* the support team has more context regarding user activity and can better support with user queries
+* users have visibility on all available services and their activity logs which makes navigation to specific services easier and suspicious activities more likely to be detected  
+
+If you are not using individual configurations for each of your services, be aware that:
+
+* fraudulent activity cannot be easily profiled and detected
+* you cannot get service specific analytics and we cannot generate these retrospectively in case you decide not to have individual configurations from the start
+* your users cannot benefit from simplified navigation and service specific information through their user journey
+
+Organisations with multiple services may have additional requirements such as:
+
+* sharing users across services - to enable this, [set up a common sector identifier](/integrate-with-integration-environment/manage-your-service-s-configuration/#choose-your-sector-identifier-uri)
+* users that want to switch between services - to support users switching between services, your service must call the `/authorize` endpoint each time a user requests access to a new service
+
+
+You can [get started with integrating with GOV.UK One Login’s integration environment](/integrate-with-integration-environment/).

--- a/source/how-gov-uk-one-login-works.html.md.erb
+++ b/source/how-gov-uk-one-login-works.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How GOV.UK One Login works 
-weight: 2
+weight: 1.5
 last_reviewed_on: 2022-11-28
 review_in: 6 months
 ---
@@ -40,7 +40,7 @@ To understand the technical flow, for example the endpoints, requests and tokens
 1. Your service makes a request to the `/userinfo` endpoint to [retrieve user information](/integrate-with-integration-environment/integrate-with-code-flow/#retrieve-user-information). You can read more about [choosing which user attributes your service can request](/integrate-with-integration-environment/choose-which-user-attributes-your-service-can-request/).
 1. Your service receives a response containing user attributes.
 
-You can [get started with integrating with GOV.UK One Login's integration environment](/integrate-with-integration-environment/).
+Find out [what to consider before you integrate your service with GOV.UK One Login](/before-integrating/).
 
 
 <%= partial "partials/links" %>

--- a/source/integrate-with-integration-environment/manage-your-service-s-configuration.html.md.erb
+++ b/source/integrate-with-integration-environment/manage-your-service-s-configuration.html.md.erb
@@ -9,7 +9,9 @@ review_in: 6 months
 
 GOV.UK One Login is an OpenID Connect (OIDC) provider.
 
-You must first register your service with GOV.UK One Login as a ‘relying party’ before being able to interact with GOV.UK One Login. You need to do this once for the integration environment and once for the production environment. An OIDC relying party is an app that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
+You must first register your service with GOV.UK One Login as a ‘relying party’ before being able to interact with GOV.UK One Login. You need to do this once for each of your services in the integration environment and the production environment.
+
+An OIDC relying party is an app that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
 
 ## Register your service to use GOV.UK One Login
 


### PR DESCRIPTION
## Why

Services that will be integrated with GOV.UK One Login need a configuration before users can start to integrate. There are 2 options: (A) individual configuration for each service or (B) a configuration for a set of services. 

The current documentation doesn't describe these options yet. Option A is preferable for various reasons - the reasons are described in the new pages. 

There is more information here: https://docs.google.com/document/d/1GmMl5J7c6Crt9aKu_bE-oRLHxNpLd23xHxsbVy6bDqs/edit

## What

This content will be added as a new section between the [How GOV.UK One Login works](https://docs.sign-in.service.gov.uk/how-gov-uk-one-login-works/) and [Integrate with GOV.UK One Login's integration environment](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/)

This requires 3 changes:

- New page describing what to do before integrating with GOV.UK One Login
- Update to [How GOV.UK One Login works](https://docs.sign-in.service.gov.uk/how-gov-uk-one-login-works/) to connect the sections up correctly - just the last sentence on the page to link to the new section instead of the integration section
- Associated change in [Manage your service's configuration with GOV.UK One Login](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/manage-your-service-s-configuration/) as requested by Phil to make it clear that you should do this for each service

## Technical writer support

This has been reviewed (pre-i'ed and 2i'ed) by Nathan Driver and Sabrina Durnberger.

## How to review

Tell reviewers how to assess your changes.
