### PR TITLE
fix typo 

### DIFF
--- a/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
+++ b/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
@@ -18,7 +18,7 @@ GOV.UK One Login uses [‘Vectors of Trust’](https://datatracker.ietf.org/doc/
   <tr>
     <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Levels of identity confidence</span></th>
     <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Vector value</span></th>
-    <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Description of the levels of identity connfidence</span></th>
+    <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Description of the levels of identity confidence</span></th>
   </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
change 'connfidence' to 'confidence'

## Why

Typo

## What

change to the word 'connfidence'

## Technical writer support

approval to merge

## How to review

Run pr and confirm typo fixed
