### PR TITLE
Fix typo to address PR-145

### DIFF
--- a/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
+++ b/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
@@ -18,7 +18,7 @@ GOV.UK One Login uses [‘Vectors of Trust’](https://datatracker.ietf.org/doc/
   <tr>
     <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Levels of identity confidence</span></th>
     <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Vector value</span></th>
-    <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Description of the levels of identity connfidence</span></th>
+    <th class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Description of the levels of identity confidence</span></th>
   </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
## Why and what

Fix typo. This addresses [PR-145](https://github.com/govuk-one-login/authentication-tech-docs/pull/145).

## Technical writer support

N/A

## How to review

Tell reviewers how to assess your changes.
