### PR TITLE
Improve language consistency

### DIFF
--- a/source/before-integrating/choose-the-level-of-authentication.html.md.erb
+++ b/source/before-integrating/choose-the-level-of-authentication.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 You’ll need to choose the level of authentication your service will require your users to have. You can find help on selecting an appropriate level of protection in the [guidance on using authenticators to protect an online service, also known as ‘GPG 44’](https://www.gov.uk/government/publications/authentication-credentials-for-online-government-services/giving-users-access-to-online-services#choosing-an-authenticator).
 
-GOV.UK One Login uses ['Vectors of Trust'](https://datatracker.ietf.org/doc/html/rfc8485). Your service can use these Vectors of Trust to request the right level of authentication for your users to gain access to your service. You’ll include your vector in the query string as part of the authorisation request you make when you integrate with Authorization Code Flow.
+GOV.UK One Login uses ['Vectors of Trust'](https://datatracker.ietf.org/doc/html/rfc8485). Your service can use these Vectors of Trust to request the right level of authentication for your users to gain access to your service. You’ll include your vector in the query string as part of the request you make when you integrate with Authorization Code Flow.
 
 GOV.UK One Login currently supports the following authentication levels, also known as ‘levels of protection’ in GPG 44.
 
@@ -35,10 +35,10 @@ GOV.UK One Login currently supports the following authentication levels, also kn
 </tbody>
 </table>
 
-You'll include your level of authentication in your authorisation request.
+You'll include your level of authentication in your request to the `/authorize` endpoint.
 
-Once you have chosen your level of authentication, you'll need to [choose the level of identity confidence][integrate.choose-level-of-confidence] if your service needs identity assurance.
+Once you have chosen your level of authentication, you'll need to [choose the level of identity confidence][integrate.choose-level-of-confidence] if your service needs identity proving.
 
-If your service does not need identity assurance, you can move on to [generate a key pair][integrate.generate-key-pair].
+If your service does not need identity proving, you can move on to [generate a key pair][integrate.generate-key-pair].
 
 <%= partial "partials/links" %>

--- a/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
+++ b/source/before-integrating/choose-the-level-of-identity-confidence.html.md.erb
@@ -7,11 +7,11 @@ review_in: 6 months
 
 # Choose the level of identity confidence for your service
 
-Using identity assurance is optional. If your service needs identity assurance, you’ll need to choose the level of identity confidence your service needs.
+Using identity proving functionality is optional. If your service needs identity proving, you’ll need to choose the level of identity confidence your service needs.
 
 You may need different levels of identity confidence at different points in your user journey. You can set the level of identity confidence your service needs for each request you make to GOV.UK One Login. Find out when and why to check someone’s identity in the [guidance about how to prove and verify someone's identity, also known as ‘GPG 45’](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity).
 
-GOV.UK One Login uses [‘Vectors of Trust’](https://datatracker.ietf.org/doc/html/rfc8485). Your service can use Vectors of Trust to request the right level of identity confidence for your users to gain access to the relevant parts of your service. You’ll include your vector in the query string as part of the authorisation request you make when you integrate with Authorization Code Flow.
+GOV.UK One Login uses [‘Vectors of Trust’](https://datatracker.ietf.org/doc/html/rfc8485). Your service can use Vectors of Trust to request the right level of identity confidence for your users to gain access to the relevant parts of your service. You’ll include your vector in the query string as part of the request to the `/authorize` endpoint you make when you integrate with Authorization Code Flow.
 
 <table class="tg">
 <thead>

--- a/source/before-integrating/choose-which-user-attributes-your-service-can-request.html.md.erb
+++ b/source/before-integrating/choose-which-user-attributes-your-service-can-request.html.md.erb
@@ -7,11 +7,11 @@ review_in: 6 months
 
 # Choose which user attributes your service can request
 
-Your service can request certain user attributes. To do this, you need to choose which ‘scopes’ or ‘claims’ your service will use and include these when you make your authorisation request.
+Your service can request certain user attributes. To do this, you need to choose which ‘scopes’ and ‘claims’ your service will use and include these when you make your request to the `/authorize` endpoint.
 
 OpenID Connect (OIDC) scopes are identifiers your application uses during authentication to authorise access to a user’s attributes, such as an email address. Each scope returns a set of user attributes contained within it. OIDC calls this set of user attributes ‘claims’.
 
-The user attributes and how you request them will depend on whether you are requesting authentication only, or authentication with identity assurance.
+The user attributes and how you request them will depend on whether you are requesting authentication only, or authentication with a level of identity confidence.
 
 <table class="tg">
 <thead>
@@ -26,12 +26,8 @@ The user attributes and how you request them will depend on whether you are requ
     <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">You can only <a href=/before-integrating/choose-which-user-attributes-your-service-can-request/#choose-which-scopes-your-service-can-request><span>request user attributes using scopes</span></a>.</span></td>
   </tr>
   <tr>
-    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">Authentication and <code>P1</code> identity assurance</span></td>
-    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">You can only <a href=/before-integrating/choose-which-user-attributes-your-service-can-request/#choose-which-scopes-your-service-can-request><span>request user attributes using scopes</span></a>.</span></td>
-  </tr>
-  <tr>
-    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">Authentication and <code>P2</code> (or higher) identity assurance</span></td>
-    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">You can request user attributes using both claims and scopes (or either claims or scopes, depending on what your service needs).</span></td>
+    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">Authentication and identity confidence</span></td>
+    <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">You can request user attributes using a combination of scopes and claims, depending on what your service needs.</td>
   </tr>
 </tbody>
 </table>
@@ -39,7 +35,8 @@ The user attributes and how you request them will depend on whether you are requ
 You'll need to agree which scopes and claims you want to use when you [register your service to use GOV.UK One Login][integrate.register-your-service].
 
 ## Choose which scopes your service can request
-`openid` is the only scope you must include. You can choose to include other scopes for your authorisation request depending on the user attributes your service needs.
+
+`openid` is the only scope you must include. You can choose to include other scopes for your request to the `/authorize` endpoint depending on the user attributes your service needs.
 
 You can find details of the scopes in the following table.
 
@@ -64,7 +61,7 @@ You can find details of the scopes in the following table.
 <p><span style="font-weight: 400;">Required</span></p>
 </td>
 <td>
-<p><span style="font-weight: 400;">OIDC authorisation requests must contain the <code>openid</code> scope value to indicate that an application intends to use the OIDC protocol.</span></p>
+<p><span style="font-weight: 400;">OIDC requests to the <code>/authorize</code> endpoint must contain the <code>openid</code> scope value to indicate that an application intends to use the OIDC protocol.</span></p>
 <br />
 <p><span style="font-weight: 400;">This will return the <code>sub</code> claim, which uniquely identifies your user.</span></p>
 </td>

--- a/source/before-integrating/create-individual-configurations-for-each-service.html.md.erb
+++ b/source/before-integrating/create-individual-configurations-for-each-service.html.md.erb
@@ -7,9 +7,9 @@ review_in: 6 months
 
 # Create a configuration for each service you’re integrating
 
-GOV.UK One Login is an OpenID Connect (OIDC) provider. An OIDC ‘relying party’ is an app that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
+GOV.UK One Login is an OpenID Connect (OIDC) provider. An OIDC ‘relying party’ is a client application that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
 
-To interact with GOV.UK One Login, you must first [register each of your services with GOV.UK One Login as a relying party][integrate.register-your-service]. You need to do this for each of the services that you want to integrate with GOV.UK One Login.
+To interact with GOV.UK One Login, you must first [register each of your services with GOV.UK One Login][integrate.register-your-service]. You need to do this for each of the services that you want to integrate with GOV.UK One Login.
 
 Part of the service’s configuration is the `client-id`, which is a unique identifier that GOV.UK One Login uses to identify your services. Each service should have a distinct `client-id`.
 

--- a/source/before-integrating/manage-your-service-s-configuration.html.md.erb
+++ b/source/before-integrating/manage-your-service-s-configuration.html.md.erb
@@ -9,9 +9,7 @@ review_in: 6 months
 
 GOV.UK One Login is an OpenID Connect (OIDC) provider.
 
-You must first register your service with GOV.UK One Login as a ‘relying party’ before being able to interact with GOV.UK One Login. You need to do this once for each of your services in the integration environment and the production environment.
-
-An OIDC relying party is an app that outsources its user authentication function to an identity provider, which in this instance is GOV.UK One Login.
+You must first register your service with GOV.UK One Login before being able to interact with GOV.UK One Login. You need to do this once for each of your services in the integration environment and the production environment.
 
 ## Register your service to use GOV.UK One Login
 
@@ -60,7 +58,7 @@ To update your service’s details with GOV.UK One Login, you need to send an em
 
 ## Progress your application to integrate with the integration environment
 
-Once the GOV.UK One Login team has registered your service, you are now a relying party for GOV.UK One Login.
+Once the GOV.UK One Login team has registered your service, you’ll receive a confirmation email.
 
 The next step before you can use the integration environment is to [integrate with GOV.UK One Login][integrate.integrate].
 

--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -220,7 +220,7 @@ Use the guidance in the following table to replace placeholder values in your ex
   <tr>
     <td class="tg-rars"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">vtr</span></td>
     <td class="tg-rars"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">Optional</span></td>
-    <td class="tg-rars"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">The </span><code>vtr</code><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> parameter represents ‘Vectors of Trust’ where you request authentication and, optionally, identity assurance. For example, if you want the medium level of authentication and medium identity confidence, request <code>vtr=[“Cl.Cm.P2”]</code>. </span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">You selected your Vector of Trust when you <a href=/before-integrating/choose-the-level-of-authentication><span>chose the level of authentication</span></a> and <a href=/before-integrating/choose-the-level-of-identity-confidence><span>the level of identity confidence</span></a> for your service.</span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">You can read more about how to combine the vectors for authentication level and identity confidence in </span><a href=https://datatracker.ietf.org/doc/html/rfc8485#section-3.1><span>Section 3 of RFC 8485</span></a>. If you need identity assurance, you must request <code>Cl.Cm</code> (the medium level of authentication) or higher (higher levels of authentication will be available soon).<br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">If you do not specify the <code>vtr</code></span><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> parameter, your service will automatically log your users in at the medium level of authentication (<code>Cl.Cm</code>).</span><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> This means you will not receive identity attributes in your response. </span><br></td>
+    <td class="tg-rars"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">The </span><code>vtr</code><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> parameter represents ‘Vectors of Trust’ where you request authentication and, optionally, identity proving. For example, if you want the medium level of authentication and medium identity confidence, request <code>vtr=[“Cl.Cm.P2”]</code>. </span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">You selected your Vector of Trust when you <a href=/before-integrating/choose-the-level-of-authentication><span>chose the level of authentication</span></a> and <a href=/before-integrating/choose-the-level-of-identity-confidence><span>the level of identity confidence</span></a> for your service.</span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">You can read more about how to combine the vectors for authentication level and identity confidence in </span><a href=https://datatracker.ietf.org/doc/html/rfc8485#section-3.1><span>Section 3 of RFC 8485</span></a>. If you need identity proving, you must request <code>Cl.Cm</code> (the medium level of authentication) or higher (higher levels of authentication will be available soon).<br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C">If you do not specify the <code>vtr</code></span><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> parameter, your service will automatically log your users in at the medium level of authentication (<code>Cl.Cm</code>).</span><span style="font-weight:400;font-style:normal;text-decoration:none;color:#0B0C0C"> This means you will not receive identity attributes in your response. </span><br></td>
   </tr>
   <tr>
     <td class="tg-ycr8"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">claims</span></td>
@@ -233,7 +233,7 @@ Use the guidance in the following table to replace placeholder values in your ex
 
 ### Generate an authorisation code
 
-If your user does not have an existing session they’re signed in to when your service makes the authorisation request, the OIDC sign-in page will open. Your user can enter their details on this page to authenticate themselves.
+If your user does not have an existing session they’re signed in to when your service makes the request to the `/authorize` endpoint, the OIDC sign-in page will open. Your user can enter their details on this page to authenticate themselves.
 
 If your user has an existing session, or after they authenticate, they will be redirected to the `redirect_uri` your service specified.
 
@@ -244,9 +244,9 @@ HTTP/1.1 302 Found
 Location: https://YOUR_REDIRECT_URI?code=AUTHORIZATION_CODE&state=xyzABC123
 ```
 
-If your authorisation request included the `state` parameter, the URI will also include this parameter.
+If your request included the `state` parameter, the URI will also include this parameter.
 
-### Error handling for ‘Make an authorisation request’
+### Error handling for ‘Make a request to the `/authorize` endpoint’
 
 To understand more about what the error is, you can look in the response. Depending on the type of error you receive, the response may contain an `error` and an `error_description` which will provide you with information.
 
@@ -278,7 +278,7 @@ Location: https://YOUR_REDIRECT_URI?error=invalid_request
       <li style="font-weight: 400;"><span style="font-weight: 400;">includes an invalid parameter value</span></li>
       <li style="font-weight: 400;"><span style="font-weight: 400;">includes a parameter more than once</span></li>
       <li style="font-weight: 400;"><span style="font-weight: 400;">not in the correct format</span></li>
-      You can </span><a href="/integrate-with-integration-environment/integrate-with-code-flow/#make-a-request-to-the-authorize-endpoint"><span>check which parameters GOV.UK One Login supports when you make an authorisation request</span></a>.
+      You can </span><a href="/integrate-with-integration-environment/integrate-with-code-flow/#make-a-request-to-the-authorize-endpoint"><span>check which parameters GOV.UK One Login supports when you make a request to the <code>/authorize</code> endpoint</span></a>.
 </td>
   </tr>
   <tr>
@@ -295,7 +295,7 @@ Location: https://YOUR_REDIRECT_URI?error=invalid_request
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">temporarily_unavailable</span></td>
-    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">If you're only making an authentication request (as opposed to requesting both authentication and identity), this error code means the GOV.UK One Login authentication server is temporarily unavailable, which might be caused by temporary overloading or planned maintenance. </span><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Make your authorisation request again in a few minutes. <br>  <br> If you're making an identity request and you get this error, it means the identity proofing and verification does not currently have capacity for this request.</span></td>
+    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">If you're only making an authentication request (as opposed to requesting both authentication and identity), this error code means the GOV.UK One Login authentication server is temporarily unavailable, which might be caused by temporary overloading or planned maintenance. </span><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Make your request again in a few minutes. <br>  <br> If you're making an identity request and you get this error, it means the identity proofing and verification does not currently have capacity for this request.</span></td>
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">access_denied</span></td>
@@ -445,7 +445,7 @@ OiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">code</span></td>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Required</span></td>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The code you received when you generated an </span><a href="/integrate-with-integration-environment/integrate-with-code-flow/#generate-an-authorisation-code"><span>authorisation code</span></a>.
-</a><span. </span></td>
+</a><span>. </span></td>
   </tr>
 </tbody>
 </table>
@@ -543,7 +543,7 @@ You can use the following table to understand the ID token’s claims.
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">nonce</span></td>
-    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The <code>nonce</code> value your application provided when you made the authorisation request.</span></td>
+    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The <code>nonce</code> value your application provided when you made the request to the <code>/authorize</code> endpoint.</span></td>
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">aud</span></td>
@@ -575,7 +575,7 @@ Now you’ve understood what’s in your ID token, you’ll need to validate it.
 1. The `aud` claim must contain your client ID you received when you [registered your service to use GOV.UK One Login][integrate.register-your-service].
 1. You must validate the signature according to the [JSON Web Signature Specification](https://datatracker.ietf.org/doc/html/rfc7515). You must first [validate that the JWT `alg` header matches](https://datatracker.ietf.org/doc/html/rfc8725#section-3.1) what was returned from the `jwks_uri`. Then you can use the value of the JWT `alg` header parameter to validate the ID token. Your application must use the keys provided by the [discovery endpoint][external.oidc-discovery].
 1. Check the current time is before the time in the `exp` claim.
-1. If you set a `nonce` value in the authorisation request, check the `nonce` value in the authorisation request matches the `nonce` value in the ID token.
+1. If you set a `nonce` value in the request to the `/authorize` endpoint, check this matches the `nonce` value in the ID token.
 1. Check the ID token is between the `auth_time` claim value (when the token was issued) and the `exp` claim value. If your ID token is outside this time window, you’ll need to request re-authentication from your user.
 
 ### Error handling for ‘Make a token request’
@@ -700,7 +700,7 @@ Content-Type: application/json
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">invalid_grant</span></td>
-    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The authorisation code is invalid or expired. This is also the error which would return if the redirect URL given in the authorisation request does not match the URL provided in this access token request.</span></td>
+    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The authorisation code is invalid or expired. This is also the error which would return if the redirect URL given in the request to the <code>/authorize</code> endpoint does not match the URL provided in this access token request.</span></td>
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">unauthorized_client</span></td>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 You must have authenticated your users before you can verify their identity.
 
-If you [requested identity assurance][integrate.choose-level-of-confidence], when you [retrieve user information with `/userinfo`](/integrate-with-integration-environment/integrate-with-code-flow/#retrieve-user-information), you’ll receive a response containing additional claims (user attributes). You may receive different claims, depending on how your user proved their identity.
+If you [requested identity proving][integrate.choose-level-of-confidence], when you [retrieve user information with `/userinfo`](/integrate-with-integration-environment/integrate-with-code-flow/#retrieve-user-information), you’ll receive a response containing additional claims (user attributes). You may receive different claims, depending on how your user proved their identity.
 
 Your service’s needs will determine how you process the other claims that GOV.UK One Login provides about your user. You’ll probably need to match against information held by your service or organisations you work with.
 


### PR DESCRIPTION
## Why and what

There are several terms that would be good to use more consistently throughout the pages. For example 'authorisation' can be used in the American or the British spelling because the OIDC definition uses the American spelling to describe the concepts. Another example is 'identity proving', as there are various words used in the standards to describe this. To ensure readers know that we are not talking about different concepts, we want to make sure we are using consistent language throughout.  

## Technical writer support

Do you need a tech writer's support, for example to review your PR?  

## How to review

Tell reviewers how to assess your changes.
