### PR TITLE
remove redundant paas manifest.yml that is no longer required

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,0 @@
----
-applications:
-- name: di-auth-tech-docs-website
-  memory: 64M
-  routes:
-    - route: auth-tech-docs.london.cloudapps.digital


### PR DESCRIPTION
## Why

The GOV.UK PaaS container hosting platform is now decommissioned

## What

Remove the `manifest.yml` file that was required for the paas deployment but is not redundant. 

## Technical writer support

Run pipeline to deploy

## How to review

ensure it deploys
