### PR TITLE
Remove outdated client library reference

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -84,7 +84,7 @@ Host: oidc.integration.account.gov.uk
 
 #### Create a URL-encoded JSON object for `<claims-request>`
 
-After you’ve made a request for authentication and identity, you should then [use a certified OIDC client library](https://openid.net/developers/certified/) to create a URL-encoded JSON object for ``<claims-request>``. Your JSON object should look similar to this example:
+After you’ve made a request for authentication and identity, you should then create a URL-encoded JSON object for ``<claims-request>``. Your JSON object should look similar to this example:
 
 ```
 {

--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -9,8 +9,6 @@ review_in: 6 months
 
 To get an access token which will allow you to access basic user information, you’ll need to integrate with [OAuth’s Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html).
 
-We recommend you [use a certified OpenID Connect (OIDC) client library](https://openid.net/developers/certified/) rather than building your own.
-
 ## Use the discovery endpoint
 
 You can use the [discovery endpoint][external.oidc-discovery] to get information needed to interact with GOV.UK One Login, for example:

--- a/source/use-sample-reference-material.html.md.erb
+++ b/source/use-sample-reference-material.html.md.erb
@@ -12,8 +12,6 @@ You can use sample reference material to see an example of how to use Authorizat
 
 <%= warning_text('You should not use the sample reference material in the production environment.') %>
 
-We recommend you [use a certified OIDC client library](https://openid.net/developers/certified/) rather than building your own.
-
 ## View Java sample reference material
 
 You can [refer to the sample reference material if you’re using Java to integrate your service to use GOV.UK One Login](https://github.com/alphagov/di-auth-stub-relying-party).


### PR DESCRIPTION
## Why

The libraries we are linking out to are a little bit out of date, and hence, we decided to remove them. Once we have compiled our own list, we will link to that instead. 

## What

Remove links to outdated libraries. 

## Technical writer support

Do you need a tech writer's support, for example to review your PR?  

## How to review

Tell reviewers how to assess your changes.
