### PR TITLE
Remove redundant GOV.UK PaaS files

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,1 +1,0 @@
-root: build

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,0 @@
----
-applications:
-- name: di-auth-tech-docs-website
-  memory: 64M
-  routes:
-    - route: auth-tech-docs.london.cloudapps.digital


### PR DESCRIPTION
## Why

The docs used to be hosted on [GOV.UK PaaS](https://cloud.service.gov.uk) but is now migrated to AWS ECS and there is some residual junk left over that is redundant.

## What

delete `Staticfile` and `manifest.yml`

## Technical writer support

Do you need a tech writer's support, for example to review your PR?   - no

## How to review

- Ensure it still runs locally using the local ruby
- Ensure it still runs locally using Docker
