### PR TITLE
Update docker tagging to authentication-tech-docs

### DIFF
--- a/preview-with-docker.sh
+++ b/preview-with-docker.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -e
 
-docker build . --tag dcs-docs
+docker build . --tag authentication-tech-docs
 
-docker run -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it dcs-docs
+docker run -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it authentication-tech-docs


### PR DESCRIPTION
## Why

Responding to [this good spot ](https://github.com/govuk-one-login/authentication-tech-docs/pull/116#issuecomment-1908822446)by @pauldougan.

Rolled as separate release to keep PR changes specific.

## What

Removes old tagging names during the docker build script. Give it a name that reflects what this repo currently does.

## Technical writer support

No

## How to review

Architects to spin up the docker image, check it's presented in `docker ps` etc in a way that makes sense.
