### PR TITLE
AP-123 Fix reference to cookies in tech docs

### DIFF
--- a/source/how-gov-uk-one-login-works.html.md.erb
+++ b/source/how-gov-uk-one-login-works.html.md.erb
@@ -23,7 +23,7 @@ GOV.UK One Login uses 2 different environments:
 1. GOV.UK One Login collects evidence of the user’s identity.
 1. GOV.UK One Login provides information about your user.
 
-You can read [guidance about cookies on GOV.UK](https://www.gov.uk/help/cookie-details) if you want to learn more about cookies.
+You can read [guidance about cookies on GOV.UK One Login](https://signin.account.gov.uk/cookies) if you want to learn more about cookies.
 
 To understand the technical flow, for example the endpoints, requests and tokens, there's a more detailed technical diagram you can use.
 


### PR DESCRIPTION
## Why

The cookies link in the docs is incorrect and point to generic GOV.UK guidance, it needs to point to specific GOV.UK One Login guidance that covers the actual cookies

## What
use the correct guidance at https://signin.account.gov.uk/cookies

## Technical writer support

Review 

## How to review

- ensure it works by testing locally
- ensure the copy makes sense in the context of the page
