### PR TITLE
Add a workaround for running ruby 3.3.0 on Apple Silicone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM ruby:3.3.0-bullseye
+FROM debian:bullseye-slim as base
+RUN apt update && apt install -y build-essential wget autoconf
+RUN wget https://github.com/postmodern/ruby-install/releases/download/v0.9.3/ruby-install-0.9.3.tar.gz \
+  && tar -xzvf ruby-install-0.9.3.tar.gz \
+  && cd ruby-install-0.9.3/ \
+  && make install
+RUN ruby-install -p https://github.com/ruby/ruby/pull/9371.diff ruby 3.3.0
+ENV PATH="/opt/rubies/ruby-3.3.0/bin:${PATH}"
 
 EXPOSE 4567:4567
 EXPOSE 35729:35729


### PR DESCRIPTION
We're having difficult building on Macs.
Looks like that'll change in Ruby 3.3.1.

Until then, let's try this workaround:
https://github.com/ruby/ruby/pull/9371#issuecomment-1893851123
