### PR TITLE
Further simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,5 @@
 # See https://help.github.com/en/articles/about-code-owners
-* @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads
+* @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads @govuk-one-login/adoption-architects @govuk-one-login/dev-platform @govuk-one-login/sse-approvers
 
-*.md @govuk-one-login/tech-writers
-*.erb @govuk-one-login/tech-writers
-*.svg @govuk-one-login/tech-writers
-
-*.scss @govuk-one-login/adoption-architects
-*.js @govuk-one-login/adoption-architects
-*.yml @govuk-one-login/adoption-architects
-*.yaml @govuk-one-login/adoption-architects
-*.conf @govuk-one-login/adoption-architects
-*.sh @govuk-one-login/adoption-architects
-*.rb @govuk-one-login/adoption-architects
+*.md @govuk-one-login/tech-writers @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads
+*.erb @govuk-one-login/tech-writers @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads


### PR DESCRIPTION
I'm a fool with my previous changes, now I understand the order of precedence.

What we want is:

- Any SSE team dev, lead dev, architect or dev platform bod can work on the docs repository
- But we'll limit content changes *.md and *.erb to tech writers, the lead writer or lead devs