### PR TITLE
Pin to harden GitHub actions

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # pin@v1
         with:
           bundler-cache: true
           ruby-version: 3.2.2

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # pin@v1
         with:
           bundler-cache: true
           ruby-version: 3.2.2
@@ -32,7 +32,7 @@ jobs:
         run: bundle exec middleman build
 
       - name: Upload to ECR and tag
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.5
+        uses: govuk-one-login/devplatform-upload-action-ecr@4e97f7e56e8be55c3cfe2198a3349c5d6b9104ea # pin@1.0.5
         with:
           role-to-assume-arn: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/require-pinned-github-actions.yml
+++ b/.github/workflows/require-pinned-github-actions.yml
@@ -1,0 +1,14 @@
+on: push
+
+name: Require Pinned Github Actions
+
+jobs:
+  harden_security:
+    name: Harden Security
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ba37328d4ea95eaf8b3bd6c6cef308f709a5f2ec # pin@v3


### PR DESCRIPTION
## Why

Harden our github action security against supply chain attacks.
I think this should be default practice

Excellent explaination here:
https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash
also
https://michaelheap.com/improve-your-github-actions-security/#using-pin-github-action

Key bit:
> Let’s consider a scenario where a malicious actor gains
> control over the actions/checkout package. This compromised package can
> now potentially manipulate the entire CI process. It can access
> environment variables used by other jobs, write to a shared directory
> that subsequent jobs process, make remote calls, inject malicious code
> into the production binary, and perform other malicious activities
>
> What many developers assume is that once they pin an action using a
> release tag, such as v3.5.2, they are safe because any new changes would
> require a new release. However, this assumption is fundamentally
> incorrect. Release tags are mutable, and a malicious actor can override
> them

How
===

There's a cli tool:
```
npm install -g pin-github-action
```

You can offer them the yaml files and it'll auto-pin for you.

## What

Pins our:
- Check pull request yml
- deploy to aws yml

Adds a new workflow to require pinned github actions

## Technical writer support

Technical change to repo

## How to review

Read the commit messages, check you agree with the approach.
Review the github workflows for syntax errors.
