### PR TITLE
Add a section to confirm to bottom of README template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,13 @@ Describe the changes you're proposing.
 
 ## Technical writer support
 
-Do you need a tech writer's support, for example to review your PR?  
+Do you need a tech writer's support, for example to review your PR?
 
 ## How to review
 
 Tell reviewers how to assess your changes.
+
+## Confirm
+
+- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
+- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes


### PR DESCRIPTION
## Why

Tech Writer provision is currently spread thin. In order to aid turnaround times and prevent branches going stale, Lead Dev for Adoption and Lead Tech writer have agreed that if we can put some of those checks into a self declariation at PR, it might make it quicker for Tech Writers to review, or allow some delgated approvals where the change is small and key questions are already answered

## What

Updates readme template

## Technical writer support

Yep

## How to review

Check the template enforces what we want it to?
