### PR TITLE
Update sector identifier guidance and registration process

### DIFF
--- a/source/before-integrating/choose-your-sector-identifier.html.md.erb
+++ b/source/before-integrating/choose-your-sector-identifier.html.md.erb
@@ -1,0 +1,46 @@
+---
+title: Choose your sector identifier
+weight: 4.99
+last_reviewed_on: 2024-02-09
+review_in: 6 months
+---
+
+# Choose your sector identifier
+
+The sector identifier is a uniform resource identifier (URI) which GOV.UK One Login uses to create a pairwise user identifier, called the ‘subject identifier’. 
+
+This means you can use the sector identifier to:
+
+* share users across multiple services
+* explicitly prevent services from sharing users
+
+You must set the sector identifier when you [register your service with GOV.UK One Login][integrate.register-your-service].
+
+<%= warning_text('Do not change the sector identifier once your service has started to sign up or migrate users. It will change the subject identifiers GOV.UK One Login creates for each individual user.') %>
+
+If you’re not sure whether you want to share users across services when onboarding your first service, you should use a generic sector identifier. Once your second service onboards, you must decide whether your services will share users. 
+
+## Set your sector identifier
+
+Make sure your sector identifier:
+
+* accurately represents your service or services which share users
+* does not contain path information 
+
+For example, you should use `https://do-a-thing.service.gov.uk` not `https://service.gov.uk/do-a-thing`. GOV.UK One Login only uses the host part of the URI. 
+
+The following table shows an example of how to set your sector identifier using the (fictional) Department of Mythical Creatures, which has 3 services:
+
+* tax your dragon 
+* register your hydra
+* report a unicorn
+
+| User sharing  | How to set your sector identifier &nbsp; | Example &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; |
+|-------------------------------------|----------------------------------|-----------------------------------------------------|
+| Share users across all services     | Set the sector identifier in all services to the same value.   | Set `https://mythical-creatures.gov.uk` as the  `sector_identifier_uri` for all 3 services. |
+| Prevent services from sharing users | Set the sector identifier in each service to a different value. | Set a separate `sector_identifier_uri` for each service: <ul><li>`http://register-your-hydra.mythical-creatures.gov.uk`</li><br><li>`http://tax-your-dragon.mythical-creatures.gov.uk`</li><br><li>`http://report-a-unicorn.mythical-creatures.gov.uk`</li></ul> |
+| Share users across some services    | Set the sector identifier in the services that share users to the same value. <br><br>Give the services that should not share users a different sector identifier. | Set `https://magical-creatures.gov.uk` as the `sector_identifier_uri` for 'register your hydra' and 'report a unicorn' to share users. <br><br> Set `https://tax-your-dragon.sport.gov.uk` as the `sector_identifier_uri` for 'tax your dragon' to have a separate user base.|
+
+
+
+<%= partial "partials/links" %>

--- a/source/before-integrating/choose-your-sector-identifier.html.md.erb
+++ b/source/before-integrating/choose-your-sector-identifier.html.md.erb
@@ -39,7 +39,7 @@ The following table shows an example of how to set your sector identifier using 
 |-------------------------------------|----------------------------------|-----------------------------------------------------|
 | Share users across all services     | Set the sector identifier in all services to the same value.   | Set `https://mythical-creatures.gov.uk` as the  `sector_identifier_uri` for all 3 services. |
 | Prevent services from sharing users | Set the sector identifier in each service to a different value. | Set a separate `sector_identifier_uri` for each service: <ul><li>`http://register-your-hydra.mythical-creatures.gov.uk`</li><br><li>`http://tax-your-dragon.mythical-creatures.gov.uk`</li><br><li>`http://report-a-unicorn.mythical-creatures.gov.uk`</li></ul> |
-| Share users across some services    | Set the sector identifier in the services that share users to the same value. <br><br>Give the services that should not share users a different sector identifier. | Set `https://magical-creatures.gov.uk` as the `sector_identifier_uri` for 'register your hydra' and 'report a unicorn' to share users. <br><br> Set `https://tax-your-dragon.sport.gov.uk` as the `sector_identifier_uri` for 'tax your dragon' to have a separate user base.|
+| Share users across some services    | Set the sector identifier in the services that share users to the same value. <br><br>Give the services that should not share users a different sector identifier. | Set `https://mythical-creatures.gov.uk` as the `sector_identifier_uri` for 'register your hydra' and 'report a unicorn' to share users. <br><br> Set `https://tax-your-dragon.mythical-creatures.gov.uk` as the `sector_identifier_uri` for 'tax your dragon' to have a separate user base.|
 
 
 

--- a/source/before-integrating/generate-a-key.html.md.erb
+++ b/source/before-integrating/generate-a-key.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Generate a key pair
-weight: 3
+weight: 5.01
 last_reviewed_on: 2021-10-14
 review_in: 6 months
 ---

--- a/source/before-integrating/set-up-your-service-s-configuration.html.md.erb
+++ b/source/before-integrating/set-up-your-service-s-configuration.html.md.erb
@@ -27,7 +27,7 @@ To register your service to use GOV.UK One Login, you need to:
 
 You need to contact the GOV.UK One Login team to register your service.
 
-Send an email to [govuk-one-login@digital.cabinet-office.gov.uk](govuk-one-login@digital.cabinet-office.gov.uk) including:
+Send an email to [govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk) including:
 
 * your service’s name
 * your service’s redirect URLs

--- a/source/before-integrating/set-up-your-service-s-configuration.html.md.erb
+++ b/source/before-integrating/set-up-your-service-s-configuration.html.md.erb
@@ -15,39 +15,35 @@ You must first register your service with GOV.UK One Login before being able to 
 
 To register your service to use GOV.UK One Login, you need to:
 
-1. Choose your `sector_identifier_uri`.
-1. Contact the GOV.UK One Login team and we'll register your service for you.
+1. [Choose your authentication level][integrate.choose-level-of-auth].
+1. [Choose the level of identity confidence for your service][integrate.choose-level-of-confidence].
+1. [Choose the scopes and claims your service needs][integrate.choose-request-scope].
+1. [Choose your sector identifier][integrate.choose-sector-id].
+1. [Generate a key pair][integrate.generate-key-pair].
+1. [Contact the GOV.UK One Login team and we’ll register your service for you][integrate.register-your-service].
 
-### Choose your `sector_identifier_uri`
-
-Your service will use a [pairwise user identifier](https://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg) when you use GOV.UK One Login.
-
-When using a pairwise identifier, GOV.UK One Login provides a unique `sub` value in the ID token to each service. This means a user ID will not be the same across services, so the value cannot be matched and used to identify an individual user.
-
-You need to specify your `sector_identifier_uri` parameter when you contact the GOV.UK One Login team to register your service. GOV.UK One Login will use this to create a unique subject identifier for your user.
-
-<%= warning_text('If you do not specify the <code>sector_identifier_uri</code>, GOV.UK One Login will use the host name of your redirect URI when we generate the subject identifier for your user. You should be aware that if your redirect URI ever changes, your users’ subject identifiers will also change.') %>
 
 ### Contact the GOV.UK One Login team to register your service
 
 You need to contact the GOV.UK One Login team to register your service.
 
-1. Start an email and include the following details.
-1. [Send the email with the completed details to govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk).
-1. The GOV.UK One Login team will register your service for you and let you know when the registration is complete.
-
-To register your service, you must send:
+Send an email to [govuk-one-login@digital.cabinet-office.gov.uk](govuk-one-login@digital.cabinet-office.gov.uk) including:
 
 * your service’s name
-* your service’s redirect URL
+* your service’s redirect URLs
 * your service’s contact email addresses - this can be a group email or multiple separate email addresses or a combination of both
-* the scopes you selected when you [chose which user attributes your service can request][integrate.choose-user-attributes]
-* the [key you generated][integrate.generate-key-pair] - only send the contents of the `public_key.pem` file and do not include the RSA headers (the words in caps above and below the key)
-* the URL you’d like your users redirected to if they log out of your service - if you do not specify one, your users will be redirected to the [default GOV.UK sign out page](https://signin.account.gov.uk/signed-out)
-* your `sector_identifier_uri` with the identifier for your sector
+* the scopes you selected when you [chose which user attributes your service can request][integrate.choose-request-scope]
+* the claims you selected when you [chose which user attributes your service can request][integrate.choose-user-attributes]
+* the public key you generated - only send the contents of the 'public_key.pem' file and do not include the RSA headers (the words in caps above and below the key)
+* the URL you’d like your users redirected to if they log out of your service - if you do not specify one, your users will be redirected to the default GOV.UK sign out page
+* your [sector identifier][integrate.choose-sector-id]
 
+The GOV.UK One Login team will send you a confirmation email once they have registered your service.
+
+#### Request signing with the RS256 algorithm 
 By default, GOV.UK One Login will sign the `id_token` JSON Web Token (JWT) using the `ES256` algorithm but some third party tooling does not support `ES256`. If your service needs an alternative algorithm, we can sign your `id_token` JWT using the `RS256` algorithm. Let us know if you need this when you register your service.
 
+#### Request logout notifications
 You can also receive user logout notifications from GOV.UK One Login. To use this, send the GOV.UK One Login team a `back_channel_logout_uri` specifying the URL you want GOV.UK One Login to send notifications to when a user who was signed into your service using GOV.UK One Login has logged out. There’s further [guidance on responding to logout notifications from GOV.UK One Login](/integrate-with-integration-environment/log-your-users-out/#responding-to-logout-notifications-from-gov-uk-one-login).
 
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -15,7 +15,7 @@
 [integrate.choose-request-scope]: /before-integrating/choose-which-user-attributes-your-service-can-request/#choose-which-scopes-your-service-can-request
 [integrate.choose-level-of-auth]: /before-integrating/choose-the-level-of-authentication/#choose-the-level-of-authentication-for-your-service
 [integrate.choose-level-of-confidence]: /before-integrating/choose-the-level-of-identity-confidence/
-[integrate.choose-sector-id]: /before-integrating/set-up-your-service-s-configuration/#choose-your-sector-identifier-uri
+[integrate.choose-sector-id]: /before-integrating/choose-your-sector-identifier/
 [integrate.generate-key-pair]: /before-integrating/generate-a-key/
 [integrate.create-configurations-for-each-service]: /before-integrating/create-individual-configurations-for-each-service/
 [integrate.client-id]: /before-integrating/create-individual-configurations-for-each-service/#understanding-the-client-identifier


### PR DESCRIPTION
## Why
We receive a lot of queries about the sector identifier which the tech docs do not explain in detail.

The sector identifier guidance needs more information so users can understand:
- what it is
- how and when to use it
- what format it should be in

## What

This PR:
- adds a separate page to explain the sector identifier and how to set it
- updates guidance around registering your service to include the sector identifier
- moves the generate key pair section to a more logical step in the process
- adds subheadings to 2 sections in the 'Contact the GOV.UK One Login team to register your service' section to make the user goal clearer

## Technical writer support

This has been through pre-i and 2i, @ImogenCraigmile to do final check. 

## How to review

Check the changes:
- are correct
- make sense
- work when running the docs up locally
- do not contain jargon or terms our users are unlikely to know

@philf999 @pauldougan to check the fictional department example! 