### PR TITLE
Add linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor/
 .DS_Store
 
 .idea/
+
+# Used by Vale for linting 
+/vale-styles/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = vale-styles
+Packages = https://github.com/alphagov/tech-docs-linter/releases/download/v0.1.0/tech-writing-style-guide.zip
+
+MinAlertLevel = error
+[*.{md,org,txt,erb,html}]
+BasedOnStyles = tech-writing-style-guide

--- a/README.md
+++ b/README.md
@@ -95,6 +95,43 @@ You should now be able to view a live preview at http://localhost:4567.
 
 Changes to the tech-docs.yml file require stopping and restarting the server to show up in the preview. You can stop it with Ctrl-C.
 
+## Linting the GOV.UK One Login Technical Documentation
+
+This repository uses [Vale](https://vale.sh/) and the [GDS Tech Docs Linter ruleset](https://github.com/alphagov/tech-docs-linter).
+
+### Installing the linter on your local machine
+
+You need to:
+
+* install [Homebrew](https://brew.sh/)
+* install [Vale](https://vale.sh/docs/vale-cli/installation/)
+
+### Linting with your code editor
+
+Many code editors provide extensions or plugins for Vale which can raise errors as you update documentation. You will still need Vale installed on your local machine.
+
+### Linting with Vale Command Line Interface (CLI)
+
+By default, Vale must be run from the same directory as this config file, unless the `--config` flag is provide with a path.
+To run the linter using Vale CLI:
+
+1. In a terminal window, navigate to your repo.
+1. Run `vale sync` to download the latest tech-docs-linter package and unzip this to your `StylesPath` listed in your config file.
+1. Run the command `vale .` to lint the entire repo or provide a path to a directory to lint only that directory for example: `vale ./source/go-live`
+
+### Updating to the latest tech docs linter ruleset
+
+If a new rule is added to the tech docs linter ruleset, you can upversion the package used by this repo when you're ready.
+A later version of the ruleset can be tested and added by:
+
+1. Create a branch.
+1. Update the package version number in the [Vale config file](.vale.ini).
+1. Run `vale sync` to download and unzip the latest package.
+1. Run `vale ./source` to test the linter.
+1. Fix any changes new ruleset throws up (preferably one commit for each rule violation).
+1. Raise a PR with the latest version number in the vale config file.
+
+
 ## Code of conduct
 
 Please refer to the `alphagov` [code of conduct](https://github.com/alphagov/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 # GOV.UK One Login technical documentation
 
-This documentation is for government services that want to integrate with GOV.UK One Login to 
+This documentation is for government services that want to integrate with GOV.UK One Login to:
 
 * authenticate their users
 * verify their users' identity  
 
-# Getting Started
+## Getting Started
 
 To see the version of Ruby used by the application, see [the ruby-version file](.ruby-version).
 
 ## Install Ruby
 
 Start by installing [rbenv](https://github.com/rbenv/rbenv) and [ruby-build](https://github.com/rbenv/ruby-build):
-```
+
+```bash
 brew upgrade rbenv ruby-build
 ```
+
 This will allow you to compile Ruby, and makes it easier to manage multiple Ruby environments (macOS comes with Ruby installed, so this simplifies things).
 
 Download the current version of Ruby that the [application uses](.ruby-version):
-```
+
+```bash
 rbenv install
 ```
 
 Install the application's dependencies:
 
-```
+```bash
 bundle install
 ```
 
@@ -40,6 +43,7 @@ bundle install # reinstall
 ```
 
 ## Making changes
+
 To make changes, edit the markdown files in the source folder.
 
 Although a single page of HTML is generated, the markdown is spread across multiple files to make it easier to manage. They can be found in `source/`.
@@ -62,13 +66,14 @@ The repository uses Github actions.
 
 Before committing any changes, the contributor should run this command in the application directory:
 
-```
+```bash
 bundle exec middleman build
 ```
 
 This command mimics the command run by the Github Actions Build Agent.
 
 ### Preview
+
 Whilst writing documentation, you can run a middleman server to preview how the published version will look in the browser.
 
 The preview is only available on your own computer. Others will not be able to access it if you give them the link.
@@ -80,13 +85,14 @@ Type one of the following to start the server:
 
 If all goes well, something like the following output will be displayed:
 
-```
+```bash
 == The Middleman is loading
 == LiveReload accepting connections from ws://192.168.0.8:35729
 == View your site at "http://Laptop.local:4567", "http://192.168.0.8:4567"
 == Inspect your site configuration at "http://Laptop.local:4567/__middleman", "http://192.168.0.8:4567/__middleman"
 You should now be able to view a live preview at http://localhost:4567.
 ```
+
 Changes to the tech-docs.yml file require stopping and restarting the server to show up in the preview. You can stop it with Ctrl-C.
 
 ## Code of conduct


### PR DESCRIPTION
## Why

The linter will in future address many of the rules set out in the GOV.UK style guide, GOV.UK technical style guide and points related to readability in the review checklist for technical writers. This should allow non-technical writers the ability to address many simple style issues themselves, improving the quality of the documentation when a technical writer is not able to support and reducing the workload for technical writers so that they can put more focus on structure and readability instead of rules.

## What

Adding a configuration file to pull the rules built by technical writing team for the linter Vale.

## Technical writer support

No

## How to review

Confirm config package links and path to style folder is appropriate
