### PR TITLE
fixed tiny typo to add an R

### DIFF
--- a/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
+++ b/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
@@ -108,7 +108,7 @@ GOV.UK One Login follows the [OIDC principles on passing request objects](https:
 
 1. Build a request object and sign it using the [private key you created][integrate.generate-key-pair] when setting up your integration with GOV.UK One Login.
 1. Encode the signed request object.
-1. Make a `GET` request replacing `YOU_REQUEST_OBJECT` with your signed and encoded request object.
+1. Make a `GET` request replacing `YOUR_REQUEST_OBJECT` with your signed and encoded request object.
 
 Use this example to make your own `GET` request, replacing the placeholder values: 
 


### PR DESCRIPTION
## Why

Small change to fix a typo and therefore improve accuracy

## What

In [secure your authorisation request parameters with JWT](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#secure-your-authorisation-request-parameters-with-jwt), it refers to YOU_REQUEST_OBJECT where it should be YOUR_REQUEST_OBJECT

## Technical writer support

Yes - needs a sanity check that I've updated it in the right place 

## How to review

Look at the files changed and check how it looks when ran locally 
