### PR TITLE
Relaxes codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # See https://help.github.com/en/articles/about-code-owners
-* @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads @govuk-one-login/adoption-architects @govuk-one-login/dev-platform @govuk-one-login/sse-approvers
 
-*.md @govuk-one-login/tech-writers @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads
-*.erb @govuk-one-login/tech-writers @govuk-one-login/adoption-lead-developers @govuk-one-login/digital-identity-lead-tech-writers @govuk-one-login/digital-identity-leads
+- @govuk-one-login/tech-writers @govuk-one-login/digital-identity-leads @govuk-one-login/adoption-architects @govuk-one-login/dev-platform @govuk-one-login/sse-approvers


### PR DESCRIPTION
Current approach wasn't working the conditionality was broken so we couldn't get the targeting we wanted where Devs / Architects own the platform and tech writers own the content.

Instead I'm relaxing the technical constraints and moving this to a policy based approach.

We'll trust people involved in the pod or at the right program level to make sensible decisions, but come to an understanding between engineering, architecture and tech writers about who should be involved in what kind of change.

We'll also ensure that Tech writers can have a periodic review point to ensure that any changes made over time are not leading to declining content standards.

Who can approve:

- Anyone in the DI leads group (Lead folk tend to be unblockers, it's cross program but if they're here they're trying to enable something with the right level of authority)
- Any Tech writer (key stakeholders for content)
- Any Architect (another key stakeholder for this content)
- Any dev platform member (rarer interventions but they helped set up this repo)
- Anyone from SSE-approvers (other devs in the pod).
