### PR TITLE
Security.txt & Thanks.txt

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,9 @@ http {
                 root /usr/share/nginx/html;
                 internal;
         }
+        rewrite ^/.well-known/security.txt$ https://vdp.cabinetoffice.gov.uk/.well-known/security.txt permanent;
     }
+
     include mime.types;
     default_type application/octet-stream;
     gzip_types text/plain text/xml text/css

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,7 @@ http {
                 internal;
         }
         rewrite ^/.well-known/security.txt$ https://vdp.cabinetoffice.gov.uk/.well-known/security.txt permanent;
+        rewrite ^/.well-known/thanks.txt$ https://vdp.cabinetoffice.gov.uk/thanks.txt permanent;
     }
 
     include mime.types;


### PR DESCRIPTION
Note [similar work on team manual](https://github.com/govuk-one-login/team-manual/pull/461)

## Why

It is [_the way_](https://gds-way.digital.cabinet-office.gov.uk/standards/vulnerability-disclosure.html#vulnerability-disclosure-and-security-txt).

Plus this is an important part of making it easy for us to get security help from the outside world.
This not really that important for the team manual given it's internal (we'd hope our staff come to our security first!)

But I think this should be in the base template for our docs templates.
I'll be adding it to the externally facing authentication-tech-docs too.

And that way if anyone tries to copy-paste this repo for any new purpose. It's _just there_.

## What

Adds nginx redriects to cab office's vulnerability disclosure `security.txt` and `thanks.txt`

## Technical writer support

Not specifically

## How to review

- Build the AWS dockerfile `docker build -f DockerfileAWS .`
- Note the image number that's produced as a result `<image>`
- `docker run  -p 8080:80  <image>`
- visit: http://127.0.0.1:8080/.well-known/security.txt -> redirected to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
- visit: http://127.0.0.1:8080/.well-known/thanks.txt -> redirected to https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt