### PR TITLE
AP-166: document the use of drawio to edit diagrams and create SVG files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you move pages around and URLs change, make sure you set up redirects from th
 ## Making changes to a diagram
 Edit the draw.io files in `source/images/originals` folder by installing and using the draw.io desktop app.
 
-Use one drawio file per diagram.
+Use one draw.io file per diagram.
 
 ### Installing the draw.io desktop app
 Run the following commands to use the draw.io desktop app from the command line.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,37 @@ In order to configure some aspects of layout, like the header, edit `config/tech
 
 If you move pages around and URLs change, make sure you set up redirects from the old URLs to the new URLs.
 
+## Making changes to a diagram
+To make changes to a diagram, you'll need to edit the `drawio` files in `source/images/originals` using the draw.io desktop app.
+
+Use one drawio file per diagram.
+
+### Install draw.io desktop app
+1. Install the draw.io desktop app using Homebrew with the following command: 
+```
+brew cask install drawio
+```
+2. Alias the binary so that you can just type `draw.io` at the command line. Use the following command to do this:
+```
+alias=draw.io='/Applications/draw.io.app/Contents/MacOS/draw.io'
+```
+### Edit and publish the diagram
+Follow these steps:
+1. Create and modify the diagram using [draw.io](https://about.draw.io/).
+1. Store the draw.io original file in `source/images/originals`.
+1. Publish the diagram as a [scalable vector graphic (SVG)](https://www.w3.org/Graphics/SVG/).
+1. Store the SVG in the `source/images` folder.
+### Useful commands
+Update a diagram:
+```
+draw.io source/images/originals/top-level-technical-diagram.drawio
+```
+Generate SVG versions of the diagrams:
+```
+draw.io -x -o source/images/top-level-technical-diagram.svg source/images/originals/top-level-technical-diagram.drawio
+draw.io -x -o source/images/technical-flow-diagram.svg source/images/originals/technical-flow-diagram.drawio
+```
+
 ## Linting the GOV.UK One Login Technical Documentation
 
 This repository uses [Vale](https://vale.sh/) and the [GDS Tech Docs Linter ruleset](https://github.com/alphagov/tech-docs-linter).

--- a/README.md
+++ b/README.md
@@ -45,23 +45,22 @@ In order to configure some aspects of layout, like the header, edit `config/tech
 If you move pages around and URLs change, make sure you set up redirects from the old URLs to the new URLs.
 
 ## Making changes to a diagram
-Edit the `drawio` files in `source/images/originals` using the draw.io desktop app.
+Edit the draw.io files in `source/images/originals` folder by installing and using the draw.io desktop app.
 
 Use one drawio file per diagram.
 
-### Install draw.io desktop app
-1. Use the following commands so that you can use draw.io at the command line (this will alias the binary): 
-```
-brew cask install drawio
-```
+### Installing the draw.io desktop app
+Run the following commands to use the draw.io desktop app from the command line.
 
 ```
-alias=draw.io='/Applications/draw.io.app/Contents/MacOS/draw.io'
+brew install --cask drawio
+alias draw.io='/Applications/draw.io.app/Contents/MacOS/draw.io'
 ```
-### Edit and publish the diagram
+
+### Editing and publishing a diagram
 Follow these steps:
-1. Create and modify the diagram using [draw.io](https://about.draw.io/).
-2. Store the draw.io original file in `source/images/originals`.
+1. Create and modify a diagram using [draw.io](https://about.draw.io/).
+2. Save the draw.io file to the `source/images/originals` folder.
 3. Publish the diagram as a [scalable vector graphic (SVG)](https://www.w3.org/Graphics/SVG/).
 4. Store the SVG in the `source/images` folder.
  
@@ -70,7 +69,7 @@ Update a diagram:
 ```
 draw.io source/images/originals/top-level-technical-diagram.drawio
 ```
-Generate SVG versions of the diagrams:
+Generate SVG versions of the diagrams and save them to the `source/images/originals` folder:
 ```
 draw.io -x -o source/images/top-level-technical-diagram.svg source/images/originals/top-level-technical-diagram.drawio
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to configure some aspects of layout, like the header, edit `config/tech
 If you move pages around and URLs change, make sure you set up redirects from the old URLs to the new URLs.
 
 ## Making changes to a diagram
-Edit the draw.io files in `source/images/originals` folder by installing and using the draw.io desktop app.
+Edit the draw.io files in the `source/images/originals` folder by installing and using the draw.io desktop app.
 
 Use one draw.io file per diagram.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Follow these steps:
 1. Create and modify a diagram using [draw.io](https://about.draw.io/).
 2. Save the draw.io file to the `source/images/originals` folder.
 3. Publish the diagram as a [scalable vector graphic (SVG)](https://www.w3.org/Graphics/SVG/).
-4. Store the SVG in the `source/images` folder.
+4. Save the SVG file to the `source/images` folder.
  
 ### Useful commands
 Update a diagram:

--- a/README.md
+++ b/README.md
@@ -45,25 +45,26 @@ In order to configure some aspects of layout, like the header, edit `config/tech
 If you move pages around and URLs change, make sure you set up redirects from the old URLs to the new URLs.
 
 ## Making changes to a diagram
-To make changes to a diagram, you'll need to edit the `drawio` files in `source/images/originals` using the draw.io desktop app.
+Edit the `drawio` files in `source/images/originals` using the draw.io desktop app.
 
 Use one drawio file per diagram.
 
 ### Install draw.io desktop app
-1. Install the draw.io desktop app using Homebrew with the following command: 
+1. Use the following commands so that you can use draw.io at the command line (this will alias the binary): 
 ```
 brew cask install drawio
 ```
-2. Alias the binary so that you can just type `draw.io` at the command line. Use the following command to do this:
+
 ```
 alias=draw.io='/Applications/draw.io.app/Contents/MacOS/draw.io'
 ```
 ### Edit and publish the diagram
 Follow these steps:
 1. Create and modify the diagram using [draw.io](https://about.draw.io/).
-1. Store the draw.io original file in `source/images/originals`.
-1. Publish the diagram as a [scalable vector graphic (SVG)](https://www.w3.org/Graphics/SVG/).
-1. Store the SVG in the `source/images` folder.
+2. Store the draw.io original file in `source/images/originals`.
+3. Publish the diagram as a [scalable vector graphic (SVG)](https://www.w3.org/Graphics/SVG/).
+4. Store the SVG in the `source/images` folder.
+ 
 ### Useful commands
 Update a diagram:
 ```
@@ -72,6 +73,7 @@ draw.io source/images/originals/top-level-technical-diagram.drawio
 Generate SVG versions of the diagrams:
 ```
 draw.io -x -o source/images/top-level-technical-diagram.svg source/images/originals/top-level-technical-diagram.drawio
+
 draw.io -x -o source/images/technical-flow-diagram.svg source/images/originals/technical-flow-diagram.drawio
 ```
 


### PR DESCRIPTION
[AP-166](https://govukverify.atlassian.net/browse/AP-166)

- how to install drawio and alias the binary
- how to edit diagrams
- how to generate SVG versions of the originals

## Why

We need to explain how to maintain the diagrams in the repo and publish SVG versions

## What

Additional content in the README

## Technical writer support

Yes

## How to review

Its only a change to the README so ensure it makes sense when rendered through GitHub

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-166]: https://govukverify.atlassian.net/browse/AP-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ