### PR TITLE
uploads gdoc content to clarify return codes

### DIFF
--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -256,10 +256,10 @@ When you use this claim and there’s an issue with the evidence your user provi
 
 1. You’ll receive an authorisation code in the `redirect_uri` instead of an `access_denied` error.
 1. Use this authorisation code to get an ID token and an access token.
-1. When you make a request to the `/userinfo` endpoint using the access token, the response may contain only authentication data, and an array of one or more `returnCode` values, for example `[{"code": "B"},{"code": "C"}]`.
-1. For security reasons, you’ll need to contact GOV.UK One Login on [govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk) for more detailed information on what each return code means.  
+1. When you make a request to the `/userinfo` endpoint using the access token, the response may contain only authentication data, and an array of one or more `returnCode` values, which will each be a letter.
+1. For security reasons, you’ll need to contact GOV.UK One Login on [govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk) for more detailed information on what issue each `returnCode` value stands for.  
 
-You may receive a return code even if a user’s identity verification is successful. Contact GOV.UK One Login on [govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk) for more detailed information on what each return code means.  
+Currently, there are 11 `returnCode` values which GOV.UK One Login could return if there’s an issue with the evidence your user provided to prove their identity. You may receive a return code even if a user’s identity verification is successful, for example, if a user is a politically exposed person. Contact GOV.UK One Login on [govuk-one-login@digital.cabinet-office.gov.uk](mailto:govuk-one-login@digital.cabinet-office.gov.uk) for more detailed information on what each return code means.  
 
 | Property         | Definition                                                                                                                                                                                                                            |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Why

Users were confused about return codes. 

## What

These changes should help users understand return codes further. 

## Technical writer support

This has been through tech writer review. 

## How to review

n/a

## Changelog

not significant enough to need changelog. 

## Confirm

- [y] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [y] Where there is any overlap I have updated or opened a PR for corresponding changes
