### PR TITLE
AP-552 - Corrected http to https in 3 example URLs

### DIFF
--- a/source/before-integrating/choose-your-sector-identifier.html.md.erb
+++ b/source/before-integrating/choose-your-sector-identifier.html.md.erb
@@ -38,7 +38,7 @@ The following table shows an example of how to set your sector identifier using 
 | User sharing  | How to set your sector identifier &nbsp; | Example &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; |
 |-------------------------------------|----------------------------------|-----------------------------------------------------|
 | Share users across all services     | Set the sector identifier in all services to the same value.   | Set `https://mythical-creatures.gov.uk` as the  `sector_identifier_uri` for all 3 services. |
-| Prevent services from sharing users | Set the sector identifier in each service to a different value. | Set a separate `sector_identifier_uri` for each service: <ul><li>`http://register-your-hydra.mythical-creatures.gov.uk`</li><br><li>`http://tax-your-dragon.mythical-creatures.gov.uk`</li><br><li>`http://report-a-unicorn.mythical-creatures.gov.uk`</li></ul> |
+| Prevent services from sharing users | Set the sector identifier in each service to a different value. | Set a separate `sector_identifier_uri` for each service: <ul><li>`https://register-your-hydra.mythical-creatures.gov.uk`</li><br><li>`https://tax-your-dragon.mythical-creatures.gov.uk`</li><br><li>`https://report-a-unicorn.mythical-creatures.gov.uk`</li></ul> |
 | Share users across some services    | Set the sector identifier in the services that share users to the same value. <br><br>Give the services that should not share users a different sector identifier. | Set `https://mythical-creatures.gov.uk` as the `sector_identifier_uri` for 'register your hydra' and 'report a unicorn' to share users. <br><br> Set `https://tax-your-dragon.mythical-creatures.gov.uk` as the `sector_identifier_uri` for 'tax your dragon' to have a separate user base.|
 
 


### PR DESCRIPTION
[https://govukverify.atlassian.net/browse/AP-552](https://govukverify.atlassian.net/browse/AP-552)

## Why

Documentation is inconsistent with OpenID spec

## What

Changing three example URLs from "http://..." to "https://"

## Technical writer support

Do you need a tech writer's support, for example to review your PR?
No. It's literally adding one letter to three URLs!

## How to review

Make sure I can spell "https". And that I haven't missed any others.

## Changelog

Not really necessary.

## Confirm

- [x ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ x] Where there is any overlap I have updated or opened a PR for corresponding changes
