### PR TITLE
BAU: Update rack to 2.2.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       ttfunk
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (2.2.19)
+    rack (2.2.20)
     rack-livereload (0.3.17)
       rack
     rainbow (3.1.1)


### PR DESCRIPTION
Updating rack to 2.2.20 to resolve some dependabot security alerts:
- https://github.com/govuk-one-login/tech-docs/security/dependabot/56
- https://github.com/govuk-one-login/tech-docs/security/dependabot/57
