### PR TITLE
SPT-1648: Fix Link Reference

### DIFF
--- a/source/before-integrating/index.html.md.erb
+++ b/source/before-integrating/index.html.md.erb
@@ -24,7 +24,7 @@ Before you can start integrating with GOV.UK One Login, you need to:
 * [choose which user attributes your service can request][integrate.choose-user-attributes]
 * [create a configuration for each service you’re integrating][integrate.create-configurations-for-each-service]
 * [set up your service’s configuration with GOV.UK One Login][integrate.set-up-configuration]
-* [ensure you are setting the User-Agent header on calls to GOV.UK One Login][set-user-agent-header]
+* [ensure you are setting the User-Agent header on calls to GOV.UK One Login][integrate.set-user-agent-header]
 
 To get started, you’ll need to [choose the level of authentication for your service][integrate.choose-level-of-auth].
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -32,6 +32,7 @@
 [integrate.make-authorize-request]: /integrate-with-integration-environment/authenticate-your-user/#make-a-request-to-the-authorize-endpoint
 [integrate.register-your-service]: /before-integrating/register-and-manage-your-service/
 [integrate.set-up-configuration]: /before-integrating/register-and-manage-your-service/
+[integrate.set-user-agent-header]: /before-integrating/set-user-agent-header/
 [integrate.use-correct-token-auth-method]: /before-integrating/use-correct-token-authentication-method/
 
 <!-- integrating links (Auth) -->


### PR DESCRIPTION
## Why

Fixes bad rendering of `before-integrating/index.html.md`

## What

Add `[integrate.set-user-agent-header]` to `_links.erb`.


## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
