### PR TITLE
AP-889 Fix broken links to admin tool

### DIFF
--- a/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
+++ b/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
@@ -104,7 +104,7 @@ If your service currently shares static keys, you can change to sharing keys thr
 
 Use the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address) to update the configuration for your test service. This will also specify the use of your exposed test environment JWKS endpoint. 
 
-1. Sign in to the [GOV.UK One Login admin tool](hhttps://admin.sign-in.service.gov.uk/register/enter-email-address).
+1. Sign in to the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address).
 2. Select your service name to view its configuration. 
 3. Scroll to **Client Authentication**.
 4. Select **Change** next to **Public key**.
@@ -133,9 +133,9 @@ You should notify GOV.UK One Login if you need to immediately revoke a key from 
 
 ### Share your fixed public key 
 
-You can configure GOV.UK One Login to use a fixed public key to validate your JWTs using the [GOV.UK One Login admin tool](https://www.gov.uk/).
+You can configure GOV.UK One Login to use a fixed public key to validate your JWTs using the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address).
 
-1. Sign in to the [GOV.UK One Login admin tool](https://www.gov.uk/).
+1. Sign in to the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address).
 2. Click your service name to view its configuration. 
 3. Go to **Client Authentication**.
 4. Select **Change** next to **Public key**.

--- a/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
+++ b/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up your public and private keys
 weight: 5.01
-last_reviewed_on: 2024-08-22
+last_reviewed_on: 2026-04-23
 review_in: 6 months
 ---
 


### PR DESCRIPTION
https://govukverify.atlassian.net/issues?filter=22923&selectedIssue=AP-889

## Why

Several links to the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address) were broken.

## What

Links to the GOV.UK One Login admin tool.

## Technical writer support

Yes

## How to review

- run locally
- check out http://localhost:4567/before-integrating/set-up-your-public-and-private-keys/#set-up-your-public-and-private-keys

## Changelog

-

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes