### PR TITLE
Correct UPRN format in example userinfo data

### DIFF
--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -33,7 +33,7 @@ Content-Type: application/json
   "https://vocab.account.gov.uk/v1/coreIdentityJWT": <JWT>,
   "https://vocab.account.gov.uk/v1/address": [
     {
-      "uprn": "10022812929",
+      "uprn": 10022812929,
       "subBuildingName": "FLAT 5",
       "buildingName": "WEST LEA",
       "buildingNumber": "16",
@@ -47,7 +47,7 @@ Content-Type: application/json
       "validFrom": "2022-01-01"
     },
     {
-      "uprn": "10002345923",
+      "uprn": 10002345923,
       "buildingName": "SAWLEY MARINA",
       "streetName": "INGWORTH ROAD",
       "dependentAddressLocality": "LONG EATON",
@@ -327,28 +327,28 @@ dependentAddressLocality</code> and <code>doubleDependentAddressLocality</code>)
 
 A sample UK (`GB`) address returned would look similar to this: 
 
-```
+```json
 {
-  uprn: "100021051133",
-  organisationName: "Acme Corporation",
-  departmentName: "Sales Department",
-  subBuildingName: "Unit 3B",
-  buildingNumber: "42",
-  buildingName: "Riverside House",
-  dependentStreetName: "Industrial Estate",
-  streetName: "River Lane",
-  doubleDependentAddressLocality: "Riverside",
-  dependentAddressLocality: "Newtown",
-  addressLocality: "Birmingham",
-  postalCode: "B12 8QT",
-  addressCountry: "GB"
-  "validFrom": "2000-01-01",
+  "uprn": 100021051133,
+  "organisationName": "Acme Corporation",
+  "departmentName": "Sales Department",
+  "subBuildingName": "Unit 3B",
+  "buildingNumber": "42",
+  "buildingName": "Riverside House",
+  "dependentStreetName": "Industrial Estate",
+  "streetName": "River Lane",
+  "doubleDependentAddressLocality": "Riverside",
+  "dependentAddressLocality": "Newtown",
+  "addressLocality": "Birmingham",
+  "postalCode": "B12 8QT",
+  "addressCountry": "GB",
+  "validFrom": "2000-01-01"
 }
 ```
 
 A sample international address returned would look similar to this: 
 
-```
+```json
 {
   "subBuildingName": "1", 
   "buildingNumber": "27", 
@@ -358,7 +358,7 @@ A sample international address returned would look similar to this:
   "addressRegion": "California"
   "postalCode": "90012",
   "addressCountry": "US",
-  "validFrom": "2000-01-01",
+  "validFrom": "2000-01-01"
 }
 ```
 


### PR DESCRIPTION
## Why

As visible in the data-vocab (https://github.com/govuk-one-login/data-vocab/blob/v2.0.2/v1/linkml-schemas/address.yaml#L133) and the authentication API (integration test data: https://github.com/govuk-one-login/authentication-api/blob/6e3ed7d2872b01b909715c95633ac931222f647a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/IdentityTestData.java#L6), the UPRN returned by One Login is in integer format, not string.

See: [AP-904](https://govukverify.atlassian.net/browse/AP-904)

## What

- Changed address UPRN value from string to integer in the example userinfo responses
- Specified JSON syntax highlighting for relevant code blocks

## Technical writer support

None needed, as the only change is to JSON examples.

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-904]: https://govukverify.atlassian.net/browse/AP-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ