### PR TITLE
AP-929 clarify that the file to upload is the public key from the public_key.pem file and not the private key

### DIFF
--- a/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
+++ b/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
@@ -137,10 +137,10 @@ You can configure GOV.UK One Login to use a fixed public key to validate your JW
 
 1. Sign in to the [GOV.UK One Login admin tool](https://admin.sign-in.service.gov.uk/register/enter-email-address).
 2. Click your service name to view its configuration. 
-3. Go to **Client Authentication**.
-4. Select **Change** next to **Public key**.
-5. Select **STATIC** under **Select a Key Source**.
-6. Add the contents of the file for your private key. 
+3. Go to **Client authentication**.
+4. Select **Change** next to **Public Key**.
+5. Select **Static Key** under **Select a Key source**.
+6. Add the contents of the `public_key.pem` file for your public key. 
 7. Select **Confirm**.
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
[AP-929](https://govukverify.atlassian.net/browse/AP-929)
## Why

Two users raised issues to report that the docs contained an error referring to the private key when it should be the public key

- #491
- #492

## What

- explain that the user should upload the public key from the `public_key.pem` file
- normalise the case of the guidance so it exactly matches the case used in the GOV.UK One Login admin tool so that is is more precise

## Technical writer support

Yes

## How to review

- spin up locally using `./bin/preview-with-docker.sh`
- open http://localhost:4567/before-integrating/set-up-your-public-and-private-keys/#change-how-you-share-your-public-keys 
- ensure the copy is consistent with the admin tool and that it mentions the public key and not the private key

## Changelog

no

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-929]: https://govukverify.atlassian.net/browse/AP-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ