### PR TITLE
REX-179: Duplicating VPC Resources for Spoke-VPC

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -10,6 +10,14 @@ Parameters:
       run.
     Type: String
 
+  # Spoke VPC Parameter Starts Here
+  SpokeVpcStackName:
+    Description: >
+      The name of the stack that defines the Spoke VPC in which the second
+      set of containers will run.
+    Type: String
+  # Spoke VPC Parameter Ends Here
+
   PipelineStackName:
     Description: "The name of the pipeline stack that deploys this application stack"
     Type: String
@@ -279,7 +287,113 @@ Resources:
         - Key: Source
           Value: govuk-one-login/tech-docs/template.yaml
 
+  #
+  # Spoke VPC - Fargate cluster resources Start Here
+  #
 
+  SpokeContainerService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref FargateCluster
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: nginx
+          ContainerPort: 80
+          TargetGroupArn: !Ref SpokeApplicationLoadBalancerTargetGroup
+      HealthCheckGracePeriodSeconds: 30
+      DesiredCount: 2
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !GetAtt SpokeContainerServiceSecurityGroup.GroupId
+          Subnets:
+            - Fn::ImportValue:
+                !Sub "${SpokeVpcStackName}-PrivateSubnetIdA"
+            - Fn::ImportValue:
+                !Sub "${SpokeVpcStackName}-PrivateSubnetIdB"
+      PropagateTags: SERVICE
+      TaskDefinition: !Ref TaskDefinition
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-SpokeContainerService"
+        - Key: Service
+          Value: ci/cd
+        - Key: Source
+          Value: govuk-one-login/team-manual/deploy/template.yaml
+    DependsOn:
+      - SpokeApplicationLoadBalancerListener
+
+  SpokeContainerAutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 2
+      MinCapacity: 2
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref FargateCluster
+          - !GetAtt SpokeContainerService.Name
+      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  SpokeContainerAutoScalingPolicy:
+    DependsOn: SpokeContainerAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: spokeContainerAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref FargateCluster
+          - !GetAtt SpokeContainerService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        TargetValue: 70
+
+  SpokeContainerServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security Group to access the Spoke Container Service
+      GroupName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - SpokeContainerService
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - "-"
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - "/"
+                          - Ref: AWS::StackId
+      SecurityGroupIngress:
+        - Description: Allow traffic from the spoke load balancer on port 80
+          SourceSecurityGroupId: !GetAtt SpokeApplicationLoadBalancerSecurityGroup.GroupId
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${SpokeVpcStackName}-VpcId"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-SpokeContainerServiceSecurityGroup"
+        - Key: Service
+          Value: ci/cd
+        - Key: Source
+          Value: govuk-one-login/team-manual/deploy/template.yaml
+  #
+  # Spoke VPC - Fargate cluster resources End Here
+  #
+
+  #
   # Application Load balancing
   #
 
@@ -408,6 +522,142 @@ Resources:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
+
+  #
+  # Spoke VPC - Application Load Balancing Starts Here
+  #
+
+  SpokeApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups:
+        - !GetAtt SpokeApplicationLoadBalancerSecurityGroup.GroupId
+      Subnets:
+        - Fn::ImportValue:
+            !Sub "${SpokeVpcStackName}-PublicSubnetIdA"Expand commentComment on line R538Resolved
+        - Fn::ImportValue:
+            !Sub "${SpokeVpcStackName}-PublicSubnetIdB"
+      Type: application
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: "true"
+        - Key: access_logs.s3.bucket
+          Value: !Ref AccessLogsBucket
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: "true"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-SpokeApplicationLoadBalancer"
+        - Key: Service
+          Value: ci/cd
+        - Key: Source
+          Value: govuk-one-login/tech-docs/template.yaml
+
+  SpokeApplicationLoadBalancerTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckEnabled: TRUE
+      HealthCheckPort: 80
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /
+      HealthCheckTimeoutSeconds: 2
+      HealthCheckIntervalSeconds: 5
+      HealthyThresholdCount: 2
+      Port: 80
+      Protocol: HTTP
+      Matcher:
+        HttpCode: 200
+      TargetType: ip
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${SpokeVpcStackName}-VpcId"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-SpokeALBTargetGroup"
+        - Key: Service
+          Value: ci/cd
+        - Key: Source
+          Value: govuk-one-login/tech-docs/template.yaml
+
+  SpokeApplicationLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Metadata:
+      checkov:
+        skip:
+          - id: "CKV_AWS_2"
+            comment: "Certificate generation must be resolved before the listener can use HTTPS"
+          - id: "CKV_AWS_103"
+            comment: "The load balancer cannot use TLS v1.2 until HTTPS is enabled"
+    Properties:
+      DefaultActions:
+        - Order: 1
+          TargetGroupArn: !Ref SpokeApplicationLoadBalancerTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref SpokeApplicationLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      Certificates:
+        - CertificateArn: !Ref TechDocsCertificate
+
+  SpokeApplicationLoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security Group for the Spoke Application Load Balancer
+      GroupName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - SpokeApplicationLoadBalancer
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - "-"
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - "/"
+                          - Ref: AWS::StackId
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${SpokeVpcStackName}-VpcId"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-SpokeALBSecurityGroup"
+        - Key: Service
+          Value: ci/cd
+        - Key: Source
+          Value: govuk-one-login/tech-docs/template.yaml
+
+  SpokeApplicationLoadBalancerSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt SpokeApplicationLoadBalancerSecurityGroup.GroupId
+      CidrIp: 0.0.0.0/0
+      Description: Allow traffic from the internet on port 443
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  SpokeApplicationLoadBalancerSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !GetAtt SpokeApplicationLoadBalancerSecurityGroup.GroupId
+      DestinationSecurityGroupId: !GetAtt SpokeContainerServiceSecurityGroup.GroupId
+      Description: Allow traffic to Spoke Container Service on port 80
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+
+  SpokeWAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref SpokeApplicationLoadBalancer
+      WebACLArn: !ImportValue docs-waf-Waf-WebAcl-arn
+
+  #
+  # Spoke VPC - Application Load Balancing Ends Here
+  #
 
   #
   # Logging
@@ -564,3 +814,18 @@ Outputs:
 
 
 
+  #
+  # Spoke VPC Outputs Start Here
+  #
+  SpokeALBDNS:
+    Description: "The DNS of the spoke application load balancer"
+    Value: !GetAtt SpokeApplicationLoadBalancer.DNSName
+    Export:
+      Name: TechDocsSpokeALBDNS
+  SpokeALBHostedZone:
+    Description: "The hosted zone ID of the spoke application load balancer"
+    Value: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
+    Export:
+      Name: TechDocsSpokeALBHostedZone
+  #
+  # Spoke VPC Outputs End Here

--- a/template.yaml
+++ b/template.yaml
@@ -535,7 +535,7 @@ Resources:
         - !GetAtt SpokeApplicationLoadBalancerSecurityGroup.GroupId
       Subnets:
         - Fn::ImportValue:
-            !Sub "${SpokeVpcStackName}-PublicSubnetIdA"Expand commentComment on line R538Resolved
+            !Sub "${SpokeVpcStackName}-PublicSubnetIdA"
         - Fn::ImportValue:
             !Sub "${SpokeVpcStackName}-PublicSubnetIdB"
       Type: application


### PR DESCRIPTION
## Why

A Transit Gateway is being deployed which requires a redeployment of the VPC due to IP subnet changes. We are looking to create a second VPC (spoke-vpc) containing duplication of VPC bound resources so that in the future a change over can occur.

Previously attempted and reverted on PR 496 as the outputs were missing. 

## What

The following resources are duplicated within template.yaml with a prefix of Spoke, and comments surrounding the duplicated resources to help clearly identify them:

ContainerServiceSecurityGroup (AWS::EC2::SecurityGroup)

ApplicationLoadBalancerSecurityGroup (AWS::EC2::SecurityGroup)

ApplicationLoadBalancer (AWS::ElasticLoadBalancingV2::LoadBalancer)

ApplicationLoadBalancerTargetGroup (AWS::ElasticLoadBalancingV2::TargetGroup)

ContainerService (AWS::ECS::Service)

ApplicationLoadBalancerListener (AWS::ElasticLoadBalancingV2::Listener)

ApplicationLoadBalancerSecurityGroupIngress (AWS::EC2::SecurityGroupIngress)

ApplicationLoadBalancerSecurityGroupEgress (AWS::EC2::SecurityGroupEgress)

ContainerAutoScalingTarget (AWS::ApplicationAutoScaling::ScalableTarget)

ContainerAutoScalingPolicy (AWS::ApplicationAutoScaling::ScalingPolicy)

WAFv2ACLAssociation (AWS::WAFv2::WebACLAssociation)

The Application Load Balancer (ALB) now uses IP addresses from the public subnet (see REX-176 for details).

## Technical writer support

No

## How to review

Please read through template.yaml and confirm the duplication of resources as per above / REX-176.
