### PR TITLE
REX-176: Pointing DNS at SpokeALB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -55,8 +55,8 @@ Resources:
       Type: A
       HostedZoneId: !ImportValue TechDocsPublicHostedZoneId
       AliasTarget:
-        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
 
   TechDocsCertificate:
     Type: AWS::CertificateManager::Certificate
@@ -76,8 +76,8 @@ Resources:
       Type: A
       HostedZoneId: !ImportValue DocsSigninPublicHostedZoneId
       AliasTarget:
-        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
 
   #DocsSigninCertificate:
   #  Type: AWS::CertificateManager::Certificate


### PR DESCRIPTION
## Why

Migrating VPC bound resources from the VPC to a SpokeVPC.

## What

TechDocsDnsRecord changed from pointing at the VPC Application Load Balancer (ALB) to pointing at the SpokeVPC Application Load Balancer. Traffic to tech-docs.account.gov.uk should then start hitting the SpokeApplicationLoadBalancer.

## Technical writer support

No

## How to review

Targets for DNSName and HostedZoneId should have been altered from ApplicationLoadBalancer to SpokeApplicationLoadBalancer.