### PR TITLE
REX-176: Removing legacy VPC resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -79,15 +79,6 @@ Resources:
         DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
         HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
 
-  #DocsSigninCertificate:
-  #  Type: AWS::CertificateManager::Certificate
-  #  Properties:
-  #    DomainName: "docs.sign-in.service.gov.uk"
-  #    DomainValidationOptions:
-  #      - DomainName: "docs.sign-in.service.gov.uk"
-  #        HostedZoneId: !ImportValue DocsSigninPublicHostedZoneId
-  #    ValidationMethod: DNS
-
   #
   # Fargate cluster
   #
@@ -105,105 +96,6 @@ Resources:
           Value: ci/cd
         - Key: Source
           Value: govuk-one-login/team-manual/deploy/template.yaml #one day
-
-  ContainerService:
-    Type: AWS::ECS::Service
-    Properties:
-      Cluster: !Ref FargateCluster
-      LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: nginx
-          ContainerPort: 80
-          TargetGroupArn: !Ref ApplicationLoadBalancerTargetGroup
-      HealthCheckGracePeriodSeconds: 30
-      DesiredCount: 2
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ContainerServiceSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue:
-                !Sub "${VpcStackName}-PrivateSubnetIdA"
-            - Fn::ImportValue:
-                !Sub "${VpcStackName}-PrivateSubnetIdB"
-      PropagateTags: SERVICE
-      TaskDefinition: !Ref TaskDefinition
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-ContainerService"
-        - Key: Service
-          Value: ci/cd
-        - Key: Source
-          Value: govuk-one-login/team-manual/deploy/template.yaml
-    DependsOn:
-      - ApplicationLoadBalancerListener
-
-  ContainerAutoScalingTarget:
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Properties:
-      MaxCapacity: 2
-      MinCapacity: 2
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref FargateCluster
-          - !GetAtt ContainerService.Name
-      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-
-  ContainerAutoScalingPolicy:
-    DependsOn: ContainerAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: containerAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref FargateCluster
-          - !GetAtt ContainerService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      TargetTrackingScalingPolicyConfiguration:
-        PredefinedMetricSpecification:
-          PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 70
-
-  ContainerServiceSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security Group to access the Container Service
-      GroupName: !Join
-        - "-"
-        - - !Ref AWS::StackName
-          - ContainerService
-          - Fn::Select:
-              - 4
-              - Fn::Split:
-                  - "-"
-                  - Fn::Select:
-                      - 2
-                      - Fn::Split:
-                          - "/"
-                          - Ref: AWS::StackId
-      SecurityGroupIngress:
-        - Description: Allow traffic from the load balancer on port 80
-          SourceSecurityGroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-          IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-      VpcId:
-        Fn::ImportValue:
-          !Sub "${VpcStackName}-VpcId"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-ContainerServiceSecurityGroup"
-        - Key: Service
-          Value: ci/cd
-        - Key: Source
-          Value: govuk-one-login/team-manual/deploy/template.yaml
 
   #
   # Fargate tasks
@@ -392,136 +284,6 @@ Resources:
   #
   # Spoke VPC - Fargate cluster resources End Here
   #
-
-  #
-  # Application Load balancing
-  #
-
-  ApplicationLoadBalancer:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Scheme: internet-facing
-      SecurityGroups:
-        - !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      Subnets:
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-FirewallSubnetIdA"
-        - Fn::ImportValue:
-            !Sub "${VpcStackName}-FirewallSubnetIdB"
-      Type: application
-
-      LoadBalancerAttributes:
-        - Key: access_logs.s3.enabled
-          Value: "true"
-        - Key: access_logs.s3.bucket
-          Value: !Ref AccessLogsBucket
-        - Key: routing.http.drop_invalid_header_fields.enabled
-          Value: "true"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-ApplicationLoadBalancer"
-        - Key: Service
-          Value: ci/cd
-        - Key: Source
-          Value: govuk-one-login/tech-docs/template.yaml
-
-  ApplicationLoadBalancerTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckEnabled: TRUE
-      HealthCheckPort: 80
-      HealthCheckProtocol: HTTP
-      HealthCheckPath: /
-      HealthCheckTimeoutSeconds: 2
-      HealthCheckIntervalSeconds: 5
-      HealthyThresholdCount: 2
-      Port: 80
-      Protocol: HTTP
-      #ProtocolVersion: HTTP1
-      Matcher:
-        HttpCode: 200
-      TargetType: ip
-      VpcId:
-        Fn::ImportValue:
-          !Sub "${VpcStackName}-VpcId"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-ALBTargetGroup"
-        - Key: Service
-          Value: ci/cd
-        - Key: Source
-          Value: govuk-one-login/tech-docs/template.yaml
-
-  ApplicationLoadBalancerListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    # checkov:skip=CKV_AWS_2:Certificate generation must be resolved before the listener can use HTTPS.
-    # checkov:skip=CKV_AWS_103:The load balancer cannot use TLS v1.2 until HTTPS is enabled.
-    Metadata:
-      checkov:
-        skip:
-          - id: "CKV_AWS_2"
-            comment: "Certificate generation must be resolved before the listener can use HTTPS"
-          - id: "CKV_AWS_103"
-            comment: "The load balancer cannot use TLS v1.2 until HTTPS is enabled"
-    Properties:
-      DefaultActions:
-        - Order: 1
-          TargetGroupArn: !Ref ApplicationLoadBalancerTargetGroup
-          Type: forward
-      LoadBalancerArn: !Ref ApplicationLoadBalancer
-      Port: 443
-      Protocol: HTTPS
-      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
-      Certificates:
-        - CertificateArn: !Ref TechDocsCertificate
-
-  ApplicationLoadBalancerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security Group for the Application Load Balancer
-      GroupName: !Join
-        - "-"
-        - - !Ref AWS::StackName
-          - ApplicationLoadBalancer
-          - Fn::Select:
-              - 4
-              - Fn::Split:
-                  - "-"
-                  - Fn::Select:
-                      - 2
-                      - Fn::Split:
-                          - "/"
-                          - Ref: AWS::StackId
-      VpcId:
-        Fn::ImportValue:
-          !Sub "${VpcStackName}-VpcId"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-ALBSecurityGroup"
-        - Key: Service
-          Value: ci/cd
-        - Key: Source
-          Value: govuk-one-login/tech-docs/template.yaml
-
-  ApplicationLoadBalancerSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
-      Description: Allow traffic from the internet on port 443
-      IpProtocol: tcp
-      FromPort: 443
-      ToPort: 443
-
-  ApplicationLoadBalancerSecurityGroupEgress:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      DestinationSecurityGroupId: !GetAtt ContainerServiceSecurityGroup.GroupId
-      Description: Allow traffic to Container Service on port 80
-      IpProtocol: tcp
-      FromPort: 80
-      ToPort: 80
 
   #
   # Spoke VPC - Application Load Balancing Starts Here
@@ -788,31 +550,12 @@ Resources:
         - Key: Source
           Value: govuk-one-login/team-manual/deploy/template.yaml
 
-
-  WAFv2ACLAssociation:
-    Type: AWS::WAFv2::WebACLAssociation
-    Properties:
-      ResourceArn: !Ref ApplicationLoadBalancer
-      WebACLArn: !ImportValue docs-waf-Waf-WebAcl-arn
-
 Outputs:
 
   PipelineStackName:
     Condition: OutputPipelineStackName
     Description: "The name of the pipeline stack that deploys this application stack"
     Value: !Ref PipelineStackName
-  ALBDNS:
-    Description: "The DNS of the application load balancer"
-    Value: !GetAtt ApplicationLoadBalancer.DNSName
-    Export:
-      Name: TechDocsALBDNS
-  ALBHostedZone:
-    Description: "The DNS of the application load balancer"
-    Value: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
-    Export:
-      Name: TechDocsALBHostedZone
-
-
 
   #
   # Spoke VPC Outputs Start Here
@@ -827,5 +570,7 @@ Outputs:
     Value: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
     Export:
       Name: TechDocsSpokeALBHostedZone
+
   #
   # Spoke VPC Outputs End Here
+  #


### PR DESCRIPTION
## Why

Migrating VPC to a SpokeVPC. Previous pull requests have seen VPC resources duplicated to resources prefixed with "Spoke" on their name and DNS A record has been repointed to the Spoke Application Load Balancer. Traffic requests are being received by the Spoke Application Load Balancer.

This pull request is to tidy the CloudFormation template.yaml and remove the legacy VPC resources as they should no longer be required.

## What

Removing the following resources:

- ContainerService
As "SpokeContainerService" on line 186 replaces it.

- ContainerAutoScalingTarget
As "SpokeContainerAutoScalingTarget" on line 219 replaces it.

- ContainerAutoScalingPolicy
As "SpokeContainerAutoScalingPolicy" on line 233 replaces it.

- ContainerServiceSecurityGroup
As "SpokeContainerServiceSecurityGroup" on line 251 replaces it.

- ApplicationLoadBalancer
As "SpokeApplicationLoadBalancer" on line 292 replaces it.

- ApplicationLoadBalancerTargetGroup
As "SpokeApplicationLoadBalancerTargetGroup" on line 319 replaces it.

- ApplicationLoadBalancerListener
As "SpokeApplicationLoadBalancerListener" on line 345 replaces it.

- ApplicationLoadBalancerSecurityGroup
As "SpokeApplicationLoadBalancerSecurityGroup" on line 366 replaces it.

- ApplicationLoadBalancerSecurityGroupIngress
As "SpokeApplicationLoadBalancerSecurityGroupIngress" on line 394 replaces it.

- ApplicationLoadBalancerSecurityGroupEgress
As "SpokeApplicationLoadBalancerSecurityGroupEgress" on line 404 replaces it.

- WAFv2ACLAssociation
As "SpokeWAFv2ACLAssociation" on line 414 replaces it.

- ALBDNS
As "SpokeALBDNS" on line 563 replaces it.

- ALBHostedZone
As "SpokeALBHostedZone" on line 568 replaces it.


Also removing "DocsSignInCertificate" as it has been commented out for some time.

## Technical writer support

No.

## How to review

Please confirm each deleted resource has a "Spoke" version.