### PR TITLE
AP-895 removed information about the vot claim

### DIFF
--- a/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
+++ b/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
@@ -380,7 +380,7 @@ You can use the following table to understand the ID token’s claims.
 | `sub`   | `sub` stands for the subject identifier or the unique ID of a user. |
 | `aud`   | `aud` stands for the audience, which will be the `client_id` you received when you [registered your service to use GOV.UK One Login][integrate.register-your-service]. |
 | `iss`   | `iss` stands for the GOV.UK One Login OpenID Provider's Issue identifier as specified in the [discovery endpoint][external.oidc-discovery]. |
-| `vot`   | `vot` stands for 'Vector of Trust'. Check the `vot` matches the authentication protection level you requested in your authorise request. The `vot` claim will only contain the credential trust level and not the level of confidence, even if you make an identity request.  |
+| `vot`   | `vot` stands for 'Vector of Trust'. |
 | `exp`   | `exp` stands for ‘expiration time’. This is the expiration time for this token, which will be an integer timestamp representing the number of seconds since the [Unix Epoch][external.unix-epoch]. |
 | `iat`   | `iat` stands for ‘issued at’. This identifies the time at which GOV.UK One Login created the JWT. You can use this claim to understand the age of the JWT.This will appear as an integer timestamp representing the number of seconds since the [Unix Epoch][external.unix-epoch]. |
 | `nonce` | The `nonce` value your application provided when you made the request to the `/authorize` endpoint. |

--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -267,12 +267,6 @@ Once GOV.UK One Login has removed the old public key from the DID document, it w
    in [the `id_token` from your token request](../authenticate-your-user/#understand-your-id-token).
 1. Check the current time is before the time in the `exp` claim.
 
-### Check your user’s level of authentication protection matches the requested level
-
-You must look for the `vot` (Vector of Trust) claim in the ID token and make sure the level of protection matches or exceeds the level a user needs to access your service. The `vot` claim will only contain the credential trust level, not the level of confidence, even if you make an identity request.
-Additionally, if you ask for medium confidence (`P2`) you must also request a protection level of `Cl.Cm`. This means logging in with two-factor authentication. If you do not do this, you'll receive the error: `invalid_request - Request vtr not valid`.
-
-
 ### Process your user’s identity credential
 
 The identity credential contains the following claims as properties of `credentialSubject`.


### PR DESCRIPTION
## Why

We were giving RPs information that was no longer required. The vot in the id token will always match, the requested vot, even if a users session currently has been authenticated to a higher level, e.g. the user has loggedon at [Cl.Cm](http://cl.cm/) and a subsequent /authorize request for Cl is sent, the vot in the id token will be Cl.


## What

Removed a small section and editing the vot description 

## Technical writer support

Do you need a tech writer's support, for example to review your PR? Yes please 

## How to review

See the files changed

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes
